### PR TITLE
Fixed pod returning error if offset wasn't met

### DIFF
--- a/Example/HNKGooglePlacesAutocomplete-Example/HNKDemoAppDelegate.m
+++ b/Example/HNKGooglePlacesAutocomplete-Example/HNKDemoAppDelegate.m
@@ -32,7 +32,7 @@ static double const kHNKLocationLongitudeNewYorkCity = 74.0059;
                                                   config.language = nil;
                                                   config.latitude = kHNKLocationLatitudeNewYorkCity;
                                                   config.longitude = kHNKLocationLongitudeNewYorkCity;
-                                                  config.offset = NSNotFound;
+                                                  config.offset = 3;
                                                   config.searchRadius = 100;
 
                                               }];

--- a/Example/HNKGooglePlacesAutocomplete-Example/HNKDemoViewController.m
+++ b/Example/HNKGooglePlacesAutocomplete-Example/HNKDemoViewController.m
@@ -87,10 +87,11 @@ static NSString *const kHNKDemoSearchResultsCellIdentifier = @"HNKDemoSearchResu
 
 - (void)handleSearchForSearchString:(NSString *)searchString
 {
-    if (![searchString isEqualToString:@""]) {
+    if ([searchString isEqualToString:@""]) {
 
-        // TODO: Add user location to search query
-        // self.searchQuery.location = self.mapView.userLocation.coordinate;
+        [self clearSearchResults];
+
+    } else {
 
         [self.searchQuery fetchPlacesForSearchQuery:searchString
                                          completion:^(NSArray *places, NSError *error) {
@@ -237,6 +238,11 @@ static NSString *const kHNKDemoSearchResultsCellIdentifier = @"HNKDemoSearchResu
 }
 
 #pragma mark Search Helpers
+
+- (void)clearSearchResults
+{
+    self.searchResults = @[];
+}
 
 - (void)handleSearchError:(NSError *)error
 {

--- a/Example/HNKGooglePlacesAutocomplete-ExampleTests/HNKGooglePlacesAutocompleteQuerySpec.m
+++ b/Example/HNKGooglePlacesAutocomplete-ExampleTests/HNKGooglePlacesAutocompleteQuerySpec.m
@@ -34,7 +34,7 @@ beforeAll(^{
                                                   config.language = @"pt_BR";
                                                   config.latitude = 50.5;
                                                   config.longitude = 150.5;
-                                                  config.offset = 50;
+                                                  config.offset = 2;
                                                   config.searchRadius = 100;
 
                                               }];
@@ -83,7 +83,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                            [[config.language should] equal:@"pt_BR"];
                            [[theValue(config.latitude) should] equal:theValue(50.5)];
                            [[theValue(config.longitude) should] equal:theValue(150.5)];
-                           [[theValue(config.offset) should] equal:theValue(50)];
+                           [[theValue(config.offset) should] equal:theValue(2)];
                            [[theValue(config.searchRadius) should] equal:theValue(100)];
 
                        });
@@ -497,7 +497,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                                                                                @"key" : testInstance.apiKey,
                                                                                @"language" : @"pt_BR",
                                                                                @"location" : @"50.500000,150.500000",
-                                                                               @"offset" : @(50),
+                                                                               @"offset" : @(2),
                                                                                @"radius" : @(100),
                                                                                @"types" : @"(cities)"
                                                                            },

--- a/Example/HNKGooglePlacesAutocomplete-ExampleTests/HNKGooglePlacesAutocompleteQuerySpec.m
+++ b/Example/HNKGooglePlacesAutocomplete-ExampleTests/HNKGooglePlacesAutocompleteQuerySpec.m
@@ -168,7 +168,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                                                                        @"key" : testInstanceWithNoConfig.apiKey,
                                                                        @"language" : @"pt_BR",
                                                                        @"location" : @"50.000000,150.000000",
-                                                                       @"offset" : @(50),
+                                                                       @"offset" : @(3),
                                                                        @"radius" : @(100),
                                                                        @"types" : @"(cities)"
                                                                    },
@@ -183,7 +183,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                                           config.language = @"pt_BR";
                                           config.latitude = 50;
                                           config.longitude = 150;
-                                          config.offset = 50;
+                                          config.offset = 3;
                                           config.searchRadius = 100;
 
                                       } completion:nil];
@@ -201,7 +201,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                                                                        @"key" : testInstance.apiKey,
                                                                        @"language" : @"pt_BR",
                                                                        @"location" : @"50.000000,150.000000",
-                                                                       @"offset" : @(50),
+                                                                       @"offset" : @(3),
                                                                        @"radius" : @(100),
                                                                        @"types" : @"(cities)"
                                                                    },
@@ -215,7 +215,7 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
                                                     config.language = @"pt_BR";
                                                     config.latitude = 50;
                                                     config.longitude = 150;
-                                                    config.offset = 50;
+                                                    config.offset = 3;
                                                     config.searchRadius = 100;
 
                                                 } completion:nil];
@@ -288,6 +288,41 @@ describe(@"HNKGooglePlacesAutocompleteQuery", ^{
             context(
                 @"Valid search query",
                 ^{
+                    context(
+                        @"Search query length less than offset",
+                        ^{
+
+                            __block HNKGooglePlacesAutocompleteQuery *testInstanceWithOffset;
+                            __block NSString *testSearchQuery;
+
+                            beforeEach(^{
+
+                                __block NSInteger offset = 15;
+
+                                testInstanceWithOffset = [[HNKGooglePlacesAutocompleteQuery alloc]
+                                        initWithAPIKey:@"jkl"
+                                    configurationBlock:^(HNKGooglePlacesAutocompleteQueryConfig *config) {
+
+                                        config.offset = offset;
+
+                                    }];
+
+                                testSearchQuery =
+                                    [@"" stringByPaddingToLength:(offset - 1)withString:@"a" startingAtIndex:0];
+
+                            });
+
+                            it(@"Should not hit the server",
+                               ^{
+
+                                   [[HNKGooglePlacesServer shouldNot] receive:@selector(GET:parameters:completion:)];
+
+                                   [testInstanceWithOffset fetchPlacesForSearchQuery:testSearchQuery completion:nil];
+
+                               });
+
+                        });
+
                     context(
                         @"JSON fetched successfully",
                         ^{

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ platform :ios, '7.0'
 
 target 'HNKGooglePlacesAutocomplete-Example' do
 
-pod 'HNKGooglePlacesAutocomplete', :git => 'https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git', :branch => 'fix/query_config_components'
+pod 'HNKGooglePlacesAutocomplete', :git => 'https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git', :branch => 'fix/query_config_offset'
 
 end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -40,17 +40,17 @@ PODS:
 
 DEPENDENCIES:
   - HNKGooglePlacesAutocomplete (from `https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git`,
-    branch `fix/query_config_components`)
+    branch `fix/query_config_offset`)
   - Kiwi (~> 2.3)
 
 EXTERNAL SOURCES:
   HNKGooglePlacesAutocomplete:
-    :branch: fix/query_config_components
+    :branch: fix/query_config_offset
     :git: https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git
 
 CHECKOUT OPTIONS:
   HNKGooglePlacesAutocomplete:
-    :commit: d536ebedc33146c8cffec3ddd9ff4eac3439e64f
+    :commit: b8115be5ec3b52b49cbe09730189c5398e30f9f2
     :git: https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git
 
 SPEC CHECKSUMS:

--- a/Example/Pods/HNKGooglePlacesAutocomplete/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
+++ b/Example/Pods/HNKGooglePlacesAutocomplete/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
@@ -169,21 +169,37 @@ static HNKGooglePlacesAutocompleteQuery *sharedQuery = nil;
         configBlock(configForRequest);
     }
 
-    if ([self isValidSearchQuery:searchQuery]) {
+    BOOL isInvalidSearchQuery = [self isInvalidSearchQuery:searchQuery];
+
+    if ([self shouldMakeServerRequestForSearchQuery:searchQuery] && !isInvalidSearchQuery) {
 
         [self serverRequestWithSearchQuery:searchQuery configuration:configForRequest completion:completion];
 
     } else {
 
-        [self completeWithErrorForInvalidSearchQuery:searchQuery completion:completion];
+        if (isInvalidSearchQuery) {
+
+            [self completeWithErrorForInvalidSearchQuery:searchQuery completion:completion];
+        }
     }
 }
 
 #pragma mark - Helpers
 
-- (BOOL)isValidSearchQuery:(NSString *)searchQuery
+- (BOOL)shouldMakeServerRequestForSearchQuery:(NSString *)searchQuery
 {
-    return ((searchQuery != nil) && ![searchQuery isEqualToString:@""]);
+    BOOL hasNoOffset = (self.configuration.offset == NSNotFound);
+    BOOL doesMeetOffset = (searchQuery.length >= self.configuration.offset);
+
+    return hasNoOffset || doesMeetOffset;
+}
+
+- (BOOL)isInvalidSearchQuery:(NSString *)searchQuery
+{
+    BOOL isNil = searchQuery == nil;
+    BOOL isEmpty = [searchQuery isEqualToString:@""];
+
+    return (isNil || isEmpty);
 }
 
 - (void)serverRequestWithSearchQuery:(NSString *)searchQuery

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -40,17 +40,17 @@ PODS:
 
 DEPENDENCIES:
   - HNKGooglePlacesAutocomplete (from `https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git`,
-    branch `fix/query_config_components`)
+    branch `fix/query_config_offset`)
   - Kiwi (~> 2.3)
 
 EXTERNAL SOURCES:
   HNKGooglePlacesAutocomplete:
-    :branch: fix/query_config_components
+    :branch: fix/query_config_offset
     :git: https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git
 
 CHECKOUT OPTIONS:
   HNKGooglePlacesAutocomplete:
-    :commit: d536ebedc33146c8cffec3ddd9ff4eac3439e64f
+    :commit: b8115be5ec3b52b49cbe09730189c5398e30f9f2
     :git: https://github.com/hkellaway/HNKGooglePlacesAutocomplete.git
 
 SPEC CHECKSUMS:

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1572 +7,1464 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0149F2D3006C861562D19498 /* KWStringUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 56EC12DDEBCF3F4D479C186A /* KWStringUtilities.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0186431A2E6B0567164EBAD3 /* KWAny.h in Headers */ = {isa = PBXBuildFile; fileRef = CD3EF45202C88562C1A46E53 /* KWAny.h */; };
-		0207DC4E3B2D0C0B9596CDA6 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 06E43F49A15467BD4BDD8D11 /* UIRefreshControl+AFNetworking.h */; };
-		037EC4B0640D2F3CF9878A5B /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B74DB16DEA2D85A82F5164 /* AFNetworkActivityIndicatorManager.m */; };
-		03FB9BBDC264E3D71EBD92B7 /* KWMessageSpying.h in Headers */ = {isa = PBXBuildFile; fileRef = C3F1C002D7BAFA5AC5DF4759 /* KWMessageSpying.h */; };
-		0428FC8A0C9C5FF8E99071A2 /* KWContextNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C13729187073B91ADF5829F /* KWContextNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		043469FCB03DFC7EBFDF623A /* KWRegisterMatchersNode.m in Sources */ = {isa = PBXBuildFile; fileRef = F64E9C695ED031D185C06578 /* KWRegisterMatchersNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0440023F7AEC1CA1CCE1A8EA /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A02550277C4B216645124103 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		04494C024B29D22E27759FB3 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = C1C32F33088BD57D15678ED2 /* AFURLRequestSerialization.m */; };
-		04E25FBE750A883CF2C04A11 /* NSProxy+KiwiVerifierAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B36EE767CA131A4A4CEB7AFB /* NSProxy+KiwiVerifierAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		05568F097AE470A9AB45CB5F /* KWItNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 06BEC211E8353D3230D0118F /* KWItNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		06772C878460AB3F929119F6 /* HNKGooglePlacesServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 22D05E3531D5FF919FC6E6DA /* HNKGooglePlacesServer.m */; };
-		073F62287AC0C2E4D1A3868F /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3600247DEF721527846D6E97 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */; };
-		078CA897AF09CFD06CCE7A3D /* KWDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 253C84B24CB86C566DDB3CFC /* KWDeviceInfo.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		08539F66344FDB82F68AF3BD /* KWMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BF2F35DB5FD04A1F92CE3703 /* KWMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		08F416176528016F6E71F274 /* KWFutureObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E2F060FF644B5BAFB3BB1E19 /* KWFutureObject.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		08F4909C3B5ABB202992A38E /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = D54940755402EBF0AB576D14 /* AFHTTPRequestOperation.m */; };
-		0A4E1CFB3091A82C679316B7 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 814A8B1366DEDD64C4EF4B02 /* EXTRuntimeExtensions.h */; };
-		0BF6655C6F2AA00E40120D64 /* KWIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = 514F9A798C30A399277D1D3B /* KWIntercept.h */; };
-		0C31D06E05B5F6EE138D334E /* KWBlockNode.m in Sources */ = {isa = PBXBuildFile; fileRef = AB9F10D2B85AFB59BEDAFB9B /* KWBlockNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0C856708673CEB2980D1F201 /* KWAsyncVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E61E71CF66B835D22D0D59C /* KWAsyncVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0D5ADA939C87F915750DF2B7 /* KWBeIdenticalToMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D25C95DF8C3FE2C2063D3D0 /* KWBeIdenticalToMatcher.h */; };
-		0FB20901A631C87AFB337668 /* KWBeZeroMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C31758A781FF3D2462845A17 /* KWBeZeroMatcher.h */; };
-		10B44A7FCB26E95005AB26F1 /* KWNilMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 629F12700A0778EB72709F29 /* KWNilMatcher.h */; };
-		14E639FD0EAA1496230AB022 /* KWConformToProtocolMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAC523455A5CD50A0D5B29B /* KWConformToProtocolMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		1771DFCCF5C5ED5F9CBF2EEB /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D031CC4916ED55FC3A0AFD /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */; };
-		184E13A59F131721738588A7 /* KWRespondToSelectorMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 91929C2D58C5A8416135B3A9 /* KWRespondToSelectorMatcher.h */; };
-		1971FB3C2367772C68E194EB /* KWGenericMatchingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B523B0A4E0B5598F0B83CA4A /* KWGenericMatchingAdditions.h */; };
-		1A99769664A16FCFF8586789 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 50348AF571000FCEBD211904 /* AFSecurityPolicy.h */; };
-		1D2A4ED96951A5C333852D48 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE751FE63E66BFA79BC9BF6 /* UIImageView+AFNetworking.h */; };
-		1F4299EAB401953C0ABAE0AD /* KWAsyncVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 552F7E31625905B16A99DAE1 /* KWAsyncVerifier.h */; };
-		210CAECA7BDF81CA5441BA2E /* KWExistVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = F0BC7E121DBE7C0A31863772 /* KWExistVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		215F51990BB4386C1D00BBCA /* KWReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 1959B391BB85A87DBB5808E1 /* KWReporting.h */; };
-		21A0A0F12BE5EDF743BD632E /* HNKGooglePlacesAutocompletePlaceSubstring.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0A3962E173AFB8ABF85897 /* HNKGooglePlacesAutocompletePlaceSubstring.m */; };
-		270026E4B7176F9A6407C25C /* KWHaveValueMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A6033149BA898A01D7CCFB81 /* KWHaveValueMatcher.h */; };
-		274BED1EDB475BE2CD935BD8 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 566B17D79DDC937640420057 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		27A7A37A15F433F8716BA0D4 /* KWBlockNode.h in Headers */ = {isa = PBXBuildFile; fileRef = B23F91B1034773CC84FD498A /* KWBlockNode.h */; };
-		289D279A4F9E60F99158E448 /* KWBeMemberOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = D546BE0F1FB90DF22AC1C82E /* KWBeMemberOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		290A5A7846EFB3951D85F5C2 /* KWCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FFD3A421ADEC11692C5FDA7 /* KWCallSite.h */; };
-		2ADEC9B17793A2501A2A61BD /* NSValue+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = AA58AC1AA206F2F88B8BA2B2 /* NSValue+KiwiAdditions.h */; };
-		2BD3FAAB7C3860B409BEF746 /* KWMock.h in Headers */ = {isa = PBXBuildFile; fileRef = CC896C8AD4820DB3566C91F6 /* KWMock.h */; };
-		2D7CA6FD97CCC15745E84762 /* KWUserDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 287266DB1819F9E456C3FC0D /* KWUserDefinedMatcher.h */; };
-		2DD91AE0368B9101FEAB9183 /* AFHTTPRequestOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 081392ADF38F84C71A2393EF /* AFHTTPRequestOperationManager.h */; };
-		3033E648EE00A98FFE87F5FE /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 34AA9B9583960E51EB1596A8 /* UIButton+AFNetworking.m */; };
-		3042D7149B1A58D4C894421B /* KWSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 184016CFBC5E5B9083FE35E6 /* KWSpec.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		30DA4B0037AD9C2066646AB4 /* KWMessageTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 642BAD7D8C7EAB8F673C6135 /* KWMessageTracker.h */; };
-		3135E978EBBF2509B600E5B0 /* KWBeEmptyMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D6541B6AEB83DE702D6D462 /* KWBeEmptyMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		3167A6FC3863B1F828ED47F4 /* KWProbePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B18D2EF337057F72769C5E9 /* KWProbePoller.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		344A12F6347E58A6E0CA5BB6 /* KWRegularExpressionPatternMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C01DE0D96B4C5EA28A859B57 /* KWRegularExpressionPatternMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		351D6345F22584E7D78B72D6 /* Kiwi.h in Headers */ = {isa = PBXBuildFile; fileRef = 503B283D7C48D72CB85B9B97 /* Kiwi.h */; };
-		358BB24E7E308C3BB1E6C7EE /* HNKGooglePlacesAutocomplete.h in Headers */ = {isa = PBXBuildFile; fileRef = E62C7358155AD7ABC39F5660 /* HNKGooglePlacesAutocomplete.h */; };
-		36234F274B7014500A83238D /* KWBeforeAllNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EA291BF1BE9F258FBB14DD6 /* KWBeforeAllNode.h */; };
-		368031F0239CB95A5588FC1C /* HNKServerFacade.h in Headers */ = {isa = PBXBuildFile; fileRef = 200F3ADB42262CE3D6662BAD /* HNKServerFacade.h */; };
-		385002FE848FEE21EDB4A995 /* NSMethodSignature+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C3725F98245305A17A32366 /* NSMethodSignature+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		39B3CE6B183342AFFE970B60 /* KWBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 6058D3062A8DF333A4783C55 /* KWBlock.h */; };
-		3C4A18D0CE951BE3DDCB7D1B /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 54599F64F8130FEA56ED3AAB /* AFSecurityPolicy.m */; };
-		3CCE37374C0F43A8834D262E /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E34CCAACC7F15837B2712D /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		3CE16D818CA3093C634C40CD /* KWMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = DF6DA094E2C869C6044F563B /* KWMatcher.h */; };
-		3FCF623FCCEF425E43FA8995 /* KWValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 489AED0CA7A744874148C38F /* KWValue.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		41303E590980FE7753F04B6E /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 399D2ED2C85934046B6A4514 /* NSInvocation+OCMAdditions.h */; };
-		41C5B353FB791A8A28666BAD /* KWBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CAC1432EACEAF9C7EC6598 /* KWBlock.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		42F2495701122EA37346C157 /* HNKGooglePlacesAutocompleteQueryConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = C849A5EEE47D2960A2EED7ED /* HNKGooglePlacesAutocompleteQueryConfig.h */; };
-		430D76129A6C7AE05CEA4809 /* KWMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 8318D271FFFC2D8C807BF761 /* KWMatchers.h */; };
-		43326239801C59BCD048056A /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AC2E0AC895237BF26C5D502 /* UIKit+AFNetworking.h */; };
-		43B64D7370A0F2290F4106A6 /* KWHaveMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A2F940EAADF93E81371E40 /* KWHaveMatcher.h */; };
-		443B185370E5F244B4F2C2EE /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B95D45685BA004A661CF0AB /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4465F416C987E7073127A2A1 /* KWItNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F41CED28A50A74D43C388E3 /* KWItNode.h */; };
-		454FC72A0EC8B3D13D1394E6 /* KWStringContainsMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A14FF3CA9DD7D496A75DBD57 /* KWStringContainsMatcher.h */; };
-		460920A91F4D8A78039A337B /* KWFailure.h in Headers */ = {isa = PBXBuildFile; fileRef = 957D4CCED793697634F0FE6C /* KWFailure.h */; };
-		460CBF854FBD4E1F5914BBDB /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92F9AF1CA7B0B78E330BB74C /* SystemConfiguration.framework */; };
-		46F188B9AE105F1C6D2DA0B3 /* KWExampleNode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0DFB53F0397C1DF256A780 /* KWExampleNode.h */; };
-		49E54B30FA0EF9C42D6F2782 /* KWInequalityMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 76B41C8DF968F6BFDD3EA1C1 /* KWInequalityMatcher.h */; };
-		4A1B6DD3D32FCABD42CFB4C3 /* NSObject+KiwiStubAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 80EDA518B365CA1EE37E0A72 /* NSObject+KiwiStubAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4A99BC6A490CEB8430E34F48 /* KWBlockRaiseMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F2B5B228C98F5ED3B80A8A3 /* KWBlockRaiseMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4B3C634774D8B3CDA65EA8D7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D79F1581656F9D57C860E43C /* XCTest.framework */; };
-		4C15FFFABFB1085AEF4EC21D /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = F2FADAACB261E7B8C528B2A3 /* AFURLResponseSerialization.h */; };
-		4C221581941530FF3130F501 /* CLPlacemark+HNKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 02ABA1AEC8FD8F076DF71180 /* CLPlacemark+HNKAdditions.m */; };
-		4E0CD178779AFACD0168B4E4 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4899804A758DF0ADCB4951 /* AFURLResponseSerialization.m */; };
-		4E0D357C02E50E3F8655B630 /* NSObject+KiwiSpyAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A844C1450535C965AF7F7B35 /* NSObject+KiwiSpyAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4E5A56FD48AEDA33B351E8B7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		4E7843DD35D9AD5264F632B9 /* KWUserDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BA8719D40386993EDBC3C32 /* KWUserDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4ECEABA5D24827D533EFD5D4 /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AD2FECEE02F33E7D99682B /* KWChangeMatcher.h */; };
-		4FD7649DD8B8E41B61DEF71B /* KWLetNode.m in Sources */ = {isa = PBXBuildFile; fileRef = ACF773841CF5AE9A43C40A11 /* KWLetNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		50F645E0499DF23875A4279D /* KWBeWithinMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FE5273F18E60934B8B3F7DA0 /* KWBeWithinMatcher.h */; };
-		5266E8699BCEEF1C3BC47FAB /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 290DD89F0E22EC1A8423CFF6 /* MTLJSONAdapter.h */; };
-		53181E4F375F6D4398FF4CCB /* KWExampleSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = EA633D4055285F175E4A0D17 /* KWExampleSuite.h */; };
-		54DCE210E72826A2475C1FD9 /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = C981976B39400360F0B01300 /* KWLet.h */; };
-		54FE0644EAB27A7231FAF688 /* KWBeMemberOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = F7E71889CE8FC74C6051CC1F /* KWBeMemberOfClassMatcher.h */; };
-		556B569DDB1CF6C64F24DB3C /* KWBeWithinMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 3870F7AEEFC88A90F5A7843F /* KWBeWithinMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		556FCA8A41069FC7B93722E7 /* KWStringPrefixMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628D4FB50A38945AD31B562 /* KWStringPrefixMatcher.h */; };
-		55A83C021CBE331D7CDBE151 /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5302C1896503B58AA0DD46 /* MTLModel+NSCoding.h */; };
-		57A56A3A4F83E353A0B2EE36 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = A81DDAB84DA0B4468EA806F3 /* UIRefreshControl+AFNetworking.m */; };
-		58A8421984339353EB259CC2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 528718D50628D958123419A4 /* CoreGraphics.framework */; };
-		58CA0FB77D75B490E822FF74 /* KWEqualMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A588CB962CE4B7C6A636689 /* KWEqualMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		58E6992A091EFE2771C97A8E /* KWExampleSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7218F9CA3729532ED94FCDE1 /* KWExampleSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		59E6CF352EE25061BB9FE1B3 /* NSObject+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BC3110E2CA77C352E2F55F /* NSObject+KiwiVerifierAdditions.h */; };
-		59EA03B14176D861872C09A7 /* KWStub.h in Headers */ = {isa = PBXBuildFile; fileRef = C8800830D40E0DB93DB55C6F /* KWStub.h */; };
-		5A49DC343EC4B78AEABBBD72 /* KWStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D6CC4FE7A02C9544A0D972E /* KWStub.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		5A663077CE5A2E7591D271D7 /* UIAlertView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 9693AF1049729EEBA3694554 /* UIAlertView+AFNetworking.m */; };
-		5A8E9AE7518C43A22DC9A4BF /* KWBeKindOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 55B98763EADB5D1DC0517869 /* KWBeKindOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		5B3DA34F2F02708050978FFA /* KWBeTrueMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B804FF6359C43EE980E650 /* KWBeTrueMatcher.h */; };
-		5DA2C86EFF9B7D0D993533D6 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D69FAB40D9AFB30395EC16 /* UIProgressView+AFNetworking.m */; };
-		5FC54F45D720DFAB04E76189 /* HNKGooglePlacesAutocompleteModel.h in Headers */ = {isa = PBXBuildFile; fileRef = B28DE78EEE80838E012C7B0F /* HNKGooglePlacesAutocompleteModel.h */; };
-		603BA07F0C9DF16D72043DED /* KWBeSubclassOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E3D4AC8A607F5E0322DF09FB /* KWBeSubclassOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		60541FC1651BAC5D0F4BA229 /* KWHaveValueMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E7704007FEA95FD1AD5C3A94 /* KWHaveValueMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6059EC276786CEA1167712FF /* KWInequalityMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F94E5915D04125DB58B0B4D3 /* KWInequalityMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		60E143C04011C676802C64BC /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 76AF7A9FF3DA0179AA4D5D16 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		612615A30098EDBB4D04C6E1 /* KWFailure.m in Sources */ = {isa = PBXBuildFile; fileRef = 524DD8795EB32D3367891014 /* KWFailure.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		61A29A4FFD4BCE6051B4C251 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 234C512D375240E8494F169F /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		62245980218D5964862DFA82 /* KWObjCUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 507903BDF700D2BCB157C2BE /* KWObjCUtilities.h */; };
-		638AF0D359F20134242F507F /* KWStringContainsMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 40446B3518C6451DA590B417 /* KWStringContainsMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		651210AB82713AABD7D38EB9 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B77F89E73CE58FC4DD469316 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		652311A688772C7371528AFF /* HNKServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 09CD708AB37C53F8AED75CE5 /* HNKServer.h */; };
-		654CDBDEFD1ECFB00BCC0081 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AAF812744AA4E992973552 /* AFURLRequestSerialization.h */; };
-		668D8AC89F22321B1705059A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5969993BFC9FB87120828703 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; };
-		6AA6B434195F161F8A71BC35 /* CLPlacemark+HNKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B305FBE817D0666537DCB0 /* CLPlacemark+HNKAdditions.h */; };
-		6B2C625F0A0DE0736FFEFF98 /* KWMessageTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B4E4E6A0D37E4D4C2F6CB3 /* KWMessageTracker.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6B4DB2323820FD024D58BD97 /* KWReceiveMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 833CF8BF2EE8EAF24EBEDB06 /* KWReceiveMatcher.h */; };
-		6CD1C0EAAC46270E9A217587 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A8689EE008D2033279A20F /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */; };
-		6D05EFEDC95B97D875D92565 /* KWMatcherFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = A9E85D413300BA1CABFE332F /* KWMatcherFactory.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6D402B2C829925A1053BC45B /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 622328EB72738488F729A0CC /* AFHTTPSessionManager.m */; };
-		6DB6A6A7C2B3B6A9B5F370CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		6E19857E2111A31763E49B1A /* KWBeforeAllNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F889D9AD0ABD06A4C589495 /* KWBeforeAllNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6E3A7826D8C9F5868BEC96C3 /* HNKGooglePlacesAutocompletePlace.h in Headers */ = {isa = PBXBuildFile; fileRef = BBF123EFFF84231EBE704A71 /* HNKGooglePlacesAutocompletePlace.h */; };
-		6F133AE7BC2E40FAA2D0B16C /* HNKGooglePlacesAutocompleteQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = CD05CAFA709E112E89C22030 /* HNKGooglePlacesAutocompleteQuery.h */; };
-		6F3DC6B61E7BA37A41F2F94F /* KWNilMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 56C0C7987C8F8744D49ABBAD /* KWNilMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6F6F91D8D1E225677910B235 /* NSInvocation+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B379A30ABBAE39E5A9E3586F /* NSInvocation+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6F90CA746AF38566A4BE3D5C /* KWWorkarounds.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E666D8CDFB2827BD290FD94 /* KWWorkarounds.h */; };
-		7002EE6A5E5A0B0084633C65 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1046E623ED4FE1E6EA3E951E /* AFHTTPRequestOperationManager.m */; };
-		708E88218563E5C0141957F2 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 89934EFF5ED5ACC58CA3990C /* AFURLConnectionOperation.m */; };
-		70C285E3017754F0EA9C3B3B /* KWReceiveMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC23F87A1E1972BE10A42D7C /* KWReceiveMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7236D89104E74FE6CC656E33 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 99F9210D9297016A8B601EDC /* AFNetworkActivityIndicatorManager.h */; };
-		726D57B571D52EEB9CE08FFC /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BB90D4A4462E6971C6588B /* UIButton+AFNetworking.h */; };
-		729113935F6E5EF2C31B3DC3 /* KWNotificationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 64F68705367E685E4E6156CD /* KWNotificationMatcher.h */; };
-		732919E0DDB015B7FDB6783B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		73B8796EB4907890E8F8CD7E /* KWInvocationCapturer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E90E538D7145B39D065ABF2 /* KWInvocationCapturer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		73EDA0A25F60451F0DAAF4E4 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 107602048702D57484FD8190 /* NSValueTransformer+MTLInversionAdditions.h */; };
-		753C80342644569157983FA8 /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9687BE7EE32CA81984436E98 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		75CECEA8EBBDB3B00AEBBAD6 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09792AC14685E9D04E440D77 /* Security.framework */; };
-		76569031B5EE46DC91234876 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BB22393EDB8A17E11272A9D4 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */; };
-		77D2CFDAA07DE9FA95C5BA2B /* KWExpectationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D70C4E6E0D4654EF0E96309 /* KWExpectationType.h */; };
-		787817CFD9E18556FC305267 /* KWExampleNodeVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D809459B07EADC892EE1FE /* KWExampleNodeVisitor.h */; };
-		78CFCBC8DCF6CF385E1781E4 /* KWGenericMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D3D8BEE1C9B8758FFD82A1 /* KWGenericMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7906E1C251902AF82635C2E1 /* KWWorkarounds.m in Sources */ = {isa = PBXBuildFile; fileRef = 67AFB1F55CB232E566BC3415 /* KWWorkarounds.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7AD480C004A0732D468293CC /* KWSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 97B0EA8F7C236D6E78477584 /* KWSpec.h */; };
-		7B05B677571D01D1137F2335 /* KWValue.h in Headers */ = {isa = PBXBuildFile; fileRef = FC2CB85DD5635F9E50FC17C7 /* KWValue.h */; };
-		7CAC2C24376FC32810482180 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = BE959059924AF347BB6E2C87 /* AFNetworkReachabilityManager.h */; };
-		7F79CB8C9F8CEAB50C89819E /* KWPendingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AC2545C01C2D38918B3134F /* KWPendingNode.h */; };
-		8004CDC36C6EB350002F336F /* HNKGooglePlacesAutocompletePlaceTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = EBF98612B0897213DD578979 /* HNKGooglePlacesAutocompletePlaceTerm.h */; };
-		818A94765F00543868366903 /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B3034C8D6C680BD6B3B7B /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		821F0CBB0B08FB53FAF7D184 /* MTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = B526551D60FA1636B3A7BFE1 /* MTLManagedObjectAdapter.h */; };
-		82561EAEB96DC88B811F9652 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 129389ACC98F2328B0CDD865 /* NSArray+MTLManipulationAdditions.h */; };
-		83E0337A28F86BEB84AD4315 /* NSNumber+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D42F0DAED7DDCA342AB76E33 /* NSNumber+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		85CC7479097E6171A8EA5089 /* HNKGooglePlacesAutocompletePlace.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAEF6BA13B2C07DE1B3AB2 /* HNKGooglePlacesAutocompletePlace.m */; };
-		8609F970DD4927D64E9B52C9 /* KWBeBetweenMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B2335F35CEF26E2D86EC55C /* KWBeBetweenMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8666475F5BAA51ADC1E53723 /* KWSymbolicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C995D56AEAEED4FCECD748D /* KWSymbolicator.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		86A5FA12B21E94E61B95E3C8 /* HNKGooglePlacesAutocompleteModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E14D398200422A4E56663811 /* HNKGooglePlacesAutocompleteModel.m */; };
-		87437DD5111042857BA4CEF8 /* KWExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DDE49CE00D1BF5DB70D6736B /* KWExample.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		87FEC0A0A686EB3CCDA77AB7 /* KWCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = A7EF4F7BB348E92EED8C8280 /* KWCallSite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		88E59013EFEBFFFF6E649E02 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1611DC102473CCFCF15BDD60 /* AFURLSessionManager.m */; };
-		8ABEF860233BAA88D15689A5 /* KWGenericMatchEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = E6BCEDBB89EC33D04924341C /* KWGenericMatchEvaluator.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8C472AD5499BD999745C22F1 /* KWRegisterMatchersNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D88BD24E3CB4EF42A100E63 /* KWRegisterMatchersNode.h */; };
-		8D5BD25A98558ADE14D24A67 /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = CB3557CDA61806D6B2598719 /* MTLReflection.h */; };
-		8D7D716E927CD5C08038CE2B /* KWGenericMatchingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = AD933846CC281937034B592A /* KWGenericMatchingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8DB04D8DFD9430FAC27D3ED2 /* KWBeforeEachNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 31930C210523BAC4C36DF829 /* KWBeforeEachNode.h */; };
-		8E88F6AABB4CCE2F4049D924 /* KWGenericMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FEF699AFF15DBBA4C41070 /* KWGenericMatcher.h */; };
-		8EF103106B52CA834E93E10C /* KWContainMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EF290D9FE55F90B190D34E3B /* KWContainMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		90CAF0DDC0C056893E414CBF /* NSObject+KiwiMockAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A0BA6FF4233DAF5C8C29446F /* NSObject+KiwiMockAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9191930DA58E5A4FBC1502AE /* KWPendingNode.m in Sources */ = {isa = PBXBuildFile; fileRef = FD893CE9B36A0CB2D5BB0705 /* KWPendingNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		91BC91F76775A0CBBA7DB812 /* KWMatching.h in Headers */ = {isa = PBXBuildFile; fileRef = 41B72D1C9AF5DE8F9674C438 /* KWMatching.h */; };
-		934EB8E948E8DB1C511D08AE /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BB0416EFA7222D95EE2DE /* AFNetworking.h */; };
-		94EC37E7EF5F22348681B04C /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FBDDD2C0610ABC8BB87E7795 /* AFNetworkReachabilityManager.m */; };
-		97B2B8B42BDB3DA1113A0C42 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		97EEF2CCFBC1A5FE067A0D20 /* KWContainMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 65901D87F22DFA6CDF20D05C /* KWContainMatcher.h */; };
-		983939BE88A0BA8A8D19E420 /* KWEqualMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = CCA546F8F3DE397A2CEC7F37 /* KWEqualMatcher.h */; };
-		9856D7935AE09F792F0BC95D /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FE9734F16C3F2C0F3934E62 /* NSDictionary+MTLManipulationAdditions.h */; };
-		986244AAE0A23E843857B8D5 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C9271E5E05D8D5FAC09ACA7 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */; };
-		98DE5D6AC29595D3986485C2 /* KWSuiteConfigurationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F315C29ED0107A0C2DA052AA /* KWSuiteConfigurationBase.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		99451DCB4B876A1F8ED0048B /* KWContainStringMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22CC793150A8EF06060FA75D /* KWContainStringMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		99F084B985A12AED04DCCE85 /* KWFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = A7641E8FDF1729CCE6B7467F /* KWFormatter.h */; };
-		9A0849A83F622C65BE3B49B1 /* KWAfterEachNode.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FC490D291EB30EA05E1396 /* KWAfterEachNode.h */; };
-		9A2F9BCDE4A6A0BC7137FDD4 /* KWStringUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 31AE1E9B659989B3DE90BBFF /* KWStringUtilities.h */; };
-		9B2F1E59B50CBCA50F08310F /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F18F715860E6BF5FADCA94 /* MTLModel.h */; };
-		9B5ABC604F60A9A020C05423 /* KWNotificationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 907B0F75545CE02D065D0A0A /* KWNotificationMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9B67961193A6764BF9255F1E /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E5CAE219A18BD25491B34C9 /* NSObject+MTLComparisonAdditions.h */; };
-		9CDBF497D9AE3A272A70B347 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 022B28936154FE99F6751FF9 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */; };
-		9DFBCFA9C7A662E0C2E2B542 /* KWBeZeroMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B4787CCF45906E24C3527722 /* KWBeZeroMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9E807CA7A58F06802CBA2060 /* KWExampleSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E32BAC80A45B250427A6DF6 /* KWExampleSuite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9F0D6587D20347BB4C58AAB0 /* HNKGooglePlacesAutocompletePlaceTerm.m in Sources */ = {isa = PBXBuildFile; fileRef = 73C9A96186E0625E38A62900 /* HNKGooglePlacesAutocompletePlaceTerm.m */; };
-		A050A6DD97E83E1F5FA70168 /* NSObject+KiwiMockAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5077A92DB8B6C8F61093497A /* NSObject+KiwiMockAdditions.h */; };
-		A2511FD5C6501E6E1D6C4346 /* KWBeTrueMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F6ECC50122BB8D15313895 /* KWBeTrueMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		A43DEA7EBA75CF9D3F84F7C0 /* KWHaveMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F42B202288760C1ED0022F88 /* KWHaveMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		A59361F5244FCDD35AC50D1A /* NSObject+KiwiSpyAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = CC717C8EF29AA29ECFFBDCFB /* NSObject+KiwiSpyAdditions.h */; };
-		A9D202D2EACF08BFF4684625 /* KWInvocationCapturer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6629E9E33001114CA0233C9A /* KWInvocationCapturer.h */; };
-		AB7D9C2DB5F1E4D9D0528073 /* KWFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F6A0D801C8E6AF4B4842636 /* KWFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		ABEDC20A90DEE67D3E3A1DA0 /* KiwiConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EFA4FD58A097B9F2E875C31A /* KiwiConfiguration.h */; };
-		ACBCB8011429C1DF7FF847C7 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8618E224A86ACCDDC8D252F5 /* AFURLSessionManager.h */; };
-		ADAD81A9E1262882C669F693 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F758D3939FA3E07C9564ACF /* Mantle.h */; };
-		ADC723185E84C3771452D195 /* KiwiMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D5CA701E1BCFC07E3492D623 /* KiwiMacros.h */; };
-		AE6222FF1A1E0D6B8AC536E4 /* KWMatchVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 5630292DF389227995A9073D /* KWMatchVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B066AFE74F1BC5E75E517610 /* KWBeforeEachNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CAEFCE0CAE766967FF57CCE /* KWBeforeEachNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B2A449D3A52223981A60DBC7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		B33D41AF4B007DBDAF6EEABC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		B4E9FAEC7315D229D1DBF9B4 /* KWBeIdenticalToMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD42021E4EE0BC7921758F5 /* KWBeIdenticalToMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B55B1E2DB10CE38B93DC6507 /* KWExampleDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E1847C045372449807F42421 /* KWExampleDelegate.h */; };
-		B56ACE7AB2C4964FCEE94E35 /* KWMatcherFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C79C8E6028D11DEA026CC7F /* KWMatcherFactory.h */; };
-		B695D60D255627D7042856A5 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8DFE431B39C713FEA278AF /* AFHTTPRequestOperation.h */; };
-		B7E92E9F7D15074A24F9A393 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F970DBF5D742A6176FE8F81 /* AFHTTPSessionManager.h */; };
-		B812259E4268BA18ACF91B10 /* KWMatchers.m in Sources */ = {isa = PBXBuildFile; fileRef = 73664B7D1F47F9B033E743AF /* KWMatchers.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B921E775EA6D73B1F05EE9A9 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2039C37E5E178A4721FCAEEC /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		B98844E12034BE035BC6EA96 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6F11442FBAB1E548DC02BB /* UIActivityIndicatorView+AFNetworking.h */; };
-		BC6A136F71A1AC97AB32B67B /* KWMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B56B7287056FCCAA2F25B2F /* KWMock.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		BD2147859ED0752D9CDAD95C /* KWCountType.h in Headers */ = {isa = PBXBuildFile; fileRef = FC97DD9187B314F2024D7310 /* KWCountType.h */; };
-		BD8981C41015A05C8923061B /* KWConformToProtocolMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F4CBD95A9689002F1ADFF5B /* KWConformToProtocolMatcher.h */; };
-		BDE81B303855F9DF9CC88ED3 /* NSInvocation+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B7CD89BD5058A4CB855232BF /* NSInvocation+KiwiAdditions.h */; };
-		BE3882283BC47BCFB107C2DF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17353691FAE342F2D70571D7 /* Foundation.framework */; };
-		BE8EF19E35611A508B09CFDB /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 715586B0584683CA46DCFE9A /* AFURLConnectionOperation.h */; };
-		C03C1BBD57A0AA6F41667EC5 /* NSProxy+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 32411DCB52B723A95472F760 /* NSProxy+KiwiVerifierAdditions.h */; };
-		C0B4BC29BDF4B43307287504 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 34BD9DE5DACB106274358294 /* UIActivityIndicatorView+AFNetworking.m */; };
-		C0B515554A8925E15502DB92 /* KWIntercept.m in Sources */ = {isa = PBXBuildFile; fileRef = 91AABE1CED27C64C4286E907 /* KWIntercept.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C32D89F7081AE79881D4C269 /* KWStringPrefixMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 90EEFEC5C1808D3309AEB101 /* KWStringPrefixMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C414D1F91558CDA25BD75C46 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 02EBE93F5FBD04BF5E534711 /* UIWebView+AFNetworking.m */; };
-		C566A14118E42AF1DF212726 /* HNKServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3704509641A36A2D62513BB8 /* HNKServer.m */; };
-		C6737C80E3F75BE204B8C1E5 /* KWContainStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C0C93AF33F7414590A8E1744 /* KWContainStringMatcher.h */; };
-		C84E596A1B787A17605FB017 /* KWAllTestsSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C071E90A2B093881945E007 /* KWAllTestsSuite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CA4643FD48DB4CCEB7F2FEAF /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F520F38C42A187E464C87AEB /* UIImageView+AFNetworking.m */; };
-		CACA91A4DFA89BB120ACB65F /* KWBeSubclassOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = B77F414322EC57E03D000540 /* KWBeSubclassOfClassMatcher.h */; };
-		CACAA8EA699F858285DCE492 /* KWMessagePattern.h in Headers */ = {isa = PBXBuildFile; fileRef = D45CD445CA24EC3B1F961BE9 /* KWMessagePattern.h */; };
-		CC06147C1D2AF40DA493013A /* KWGenericMatchEvaluator.h in Headers */ = {isa = PBXBuildFile; fileRef = 679C1158B8BAAD952684864D /* KWGenericMatchEvaluator.h */; };
-		CC4388D8A886D0D6DAA3A164 /* KWBeEmptyMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = B823608C11E6630A0D1DD9E6 /* KWBeEmptyMatcher.h */; };
-		CC8322E52150569B9A3A9AA5 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 339EB1AC3F31B193AC74A33D /* UIWebView+AFNetworking.h */; };
-		CC8B16C0283D0B981A0F1885 /* KWExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 54952A3904808E7911D2CF44 /* KWExample.h */; };
-		CF1292BE6372C2A71E930F3A /* KWBeKindOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = BB7DCF24D68837822F951E4E /* KWBeKindOfClassMatcher.h */; };
-		CF535E1B5E6FF2D090517E83 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BCC1510FCC6D08CA800CE61 /* NSError+MTLModelException.h */; };
-		CF6068133427914D2A984D2E /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66C3005DEAE02A9C5F534AE5 /* MTLValueTransformer.h */; };
-		CF66110B9C47C7A62AFAC5C8 /* KWRegularExpressionPatternMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E30C9D4AACB91267C2BD9B4 /* KWRegularExpressionPatternMatcher.h */; };
-		CF83FDC7687172E6593BE392 /* KWNull.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBA2FA4976870BA76122515 /* KWNull.h */; };
-		CFB7FE8E436F29174BE5165F /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CC1E1865FB80ADFE9A30171 /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D112079161568757DC4B228A /* KWMatchVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 42590BEF82B08D7CAF608BA5 /* KWMatchVerifier.h */; };
-		D2E1DF99337A4D219CFF7DB1 /* MTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = C630E66B948CBA4EB25A0040 /* MTLManagedObjectAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D40E909594A8AC76D2246D1B /* NSNumber+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 32199018EA77754E2EB30C81 /* NSNumber+KiwiAdditions.h */; };
-		D42D2822DE347CA96AF8EF93 /* KWContextNode.h in Headers */ = {isa = PBXBuildFile; fileRef = CF12D98189040C5F6F39B5B8 /* KWContextNode.h */; };
-		D5765D3C17A54A008CA7DD6D /* KWObjCUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7CAC1595068A552CFA9C00 /* KWObjCUtilities.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D6174C95CE0F04C5FB2A7500 /* KiwiBlockMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 83BF94C1175D1827277213AC /* KiwiBlockMacros.h */; };
-		D67467BECD94488910074B8D /* KWMessagePattern.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F438AB2D67392E51FC356C0 /* KWMessagePattern.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D6B08FDD53E3C7BF34562FB7 /* KWRespondToSelectorMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CE228954A091185C7B66DD3 /* KWRespondToSelectorMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D72F192F38EBB07F07B7B0D7 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA477C0733A7F62246D92AE /* MobileCoreServices.framework */; };
-		D739C2436A629CB2517F448D /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0211BCFAE34E1F9DB9A3CC67 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */; };
-		D772E0F4A382157FE87D59FD /* KWAfterAllNode.h in Headers */ = {isa = PBXBuildFile; fileRef = D0DFA811837E110097548562 /* KWAfterAllNode.h */; };
-		DBA8E1707AEA5215D6E6A8C0 /* KWVerifying.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A439E08AA80A119515B78C7 /* KWVerifying.h */; };
-		DC4F5A9415F146AC7D19EFC6 /* KWProbePoller.h in Headers */ = {isa = PBXBuildFile; fileRef = F7E0417F2C086086102C458C /* KWProbePoller.h */; };
-		DD52DA8D049C86C6A3932027 /* KWSuiteConfigurationBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 44F82ABA4EFB063310CAEB56 /* KWSuiteConfigurationBase.h */; };
-		DE85DD2602AD9006930F2EBE /* KWNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FDF1FF4209B5612BD8BD21A /* KWNull.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		DE935D77F5709A3527905B66 /* KWAfterEachNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 03FEAF0F394038598BB17F37 /* KWAfterEachNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E04E16E04C5C8489C6A0D172 /* KWBeBetweenMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B1CAE77C0A82214EE965418 /* KWBeBetweenMatcher.h */; };
-		E26A971052A40047405A1541 /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EF1418F4699618D44A7C4A1 /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E45BB6FECCE0A94567870364 /* NSValue+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52048C116FAE60E1A66EE03 /* NSValue+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E58CFE7D6EEE61BC37E2702C /* NSMethodSignature+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A4E56118DD2D0E6A6082F715 /* NSMethodSignature+KiwiAdditions.h */; };
-		E6C78D411835B9653985367B /* UIAlertView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A3B3749CA6F3E5BC0A7E4B /* UIAlertView+AFNetworking.h */; };
-		E715DB0E1F49AE99ABE805FD /* KWAfterAllNode.m in Sources */ = {isa = PBXBuildFile; fileRef = C0964C150FEF43E7E4ADCF86 /* KWAfterAllNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E72F87F28D0DC272D4E459EB /* KWSymbolicator.h in Headers */ = {isa = PBXBuildFile; fileRef = E4517F0FEB205454DC86A3A0 /* KWSymbolicator.h */; };
-		E91251FFA07C3000C683EA19 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A82A07158552AAD01985F4E /* KWChangeMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E912E00D5FE032F908494F4F /* HNKGooglePlacesAutocompleteQueryConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = F5AE4FB643934531473F9160 /* HNKGooglePlacesAutocompleteQueryConfig.m */; };
-		E9B6990CB4FF8F6D623C4311 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B241C5797BF73CAD17DEE03 /* metamacros.h */; };
-		EB1488894260938DF9243E20 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = BD940068FC02B7E9843F1D43 /* UIProgressView+AFNetworking.h */; };
-		EE583341AC98CDD913168B32 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F831B34D33FF8BD23A15AFDB /* EXTScope.h */; };
-		F05703B22B95462CB73D6681 /* KWCaptureSpy.m in Sources */ = {isa = PBXBuildFile; fileRef = 16F2D9EBD8FFF3D5438D6C98 /* KWCaptureSpy.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		F21F97487F8AACC73DBB81BC /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CD00EFE92810301CEB7BB9B2 /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		F2D3E6492CF64406D310CDA7 /* KWCaptureSpy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F52229D35D28DCA6AB72158 /* KWCaptureSpy.h */; };
-		F34D0B6E2788C8BF597D6BAB /* HNKGooglePlacesAutocompleteQueryResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = AFDA29167395549A876336AB /* HNKGooglePlacesAutocompleteQueryResponse.m */; };
-		F42968F591EA3C2ED0CFCE78 /* KWDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9C128C1678730ABEC08982 /* KWDeviceInfo.h */; };
-		F5113C730DC860A85100BAE3 /* KWExistVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = B1785E19D8C6C1D8A8DD4C10 /* KWExistVerifier.h */; };
-		F5DC509F927E996D6DFA557F /* HNKGooglePlacesAutocompletePlaceSubstring.h in Headers */ = {isa = PBXBuildFile; fileRef = DD0C618A00A60E95D57CB846 /* HNKGooglePlacesAutocompletePlaceSubstring.h */; };
-		F71E69A3BEE32D549F298384 /* NSObject+KiwiVerifierAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D3D5832CB893C566BFABECE /* NSObject+KiwiVerifierAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		F819734B186C06A4DE7A2997 /* NSObject+KiwiStubAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D73B3869B812FE56D84D1B6B /* NSObject+KiwiStubAdditions.h */; };
-		F84D791EEA72B12790C30E67 /* HNKGooglePlacesServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 366814AEF59CB4783023E14A /* HNKGooglePlacesServer.h */; };
-		F864A5714EBB0C2372825456 /* KWAny.m in Sources */ = {isa = PBXBuildFile; fileRef = 29E999622A0EFB0F197D3F35 /* KWAny.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		F973E950711AB175D6CAFDF4 /* HNKGooglePlacesAutocompleteQueryResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 31D6F826354B442AB08808D9 /* HNKGooglePlacesAutocompleteQueryResponse.h */; };
-		F99BF333A2C6A2336437D50F /* KWBlockRaiseMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = F17E9250A54A1DEB562E8A70 /* KWBlockRaiseMatcher.h */; };
-		FBE51CDF0A763F4860377D10 /* HNKGooglePlacesAutocompleteQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BA0D05990AE655DBC165CA3 /* HNKGooglePlacesAutocompleteQuery.m */; };
-		FC48B26E00A1F7DB9D3222D5 /* KWProbe.h in Headers */ = {isa = PBXBuildFile; fileRef = 7651FB03E103BED64B9F65CA /* KWProbe.h */; };
-		FCE5516AB52C0D098C83CC40 /* KWExampleSuiteBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = EC351FCC3271E6CE21F92B3C /* KWExampleSuiteBuilder.h */; };
-		FCFAC10727967D5361F8F099 /* KWFutureObject.h in Headers */ = {isa = PBXBuildFile; fileRef = DCDCF0CF41B32F57A41130EE /* KWFutureObject.h */; };
-		FF706F5C100CFE369C6F361C /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8482339B283BC309E62FC7FD /* EXTKeyPathCoding.h */; };
-		FFD06C32B26204726B7A16D2 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E02493ABB2EF8687A943186 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		FFE0FCB4C458B92C781982F4 /* KWLetNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B475A6A05A55309B0F7EC7D /* KWLetNode.h */; };
+		0105C638D911E3799E2482A6 /* KWHaveValueMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 20DAC95D224EAFE70DB75ADC /* KWHaveValueMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		019DB40870B3A3CB67BE19E3 /* NSMethodSignature+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2581A7786B7C24654918E1CD /* NSMethodSignature+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		0216303B07926FDCB5278078 /* KWConformToProtocolMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BA5EA7F6390A5FD58B503C1 /* KWConformToProtocolMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		04C269902AC319929F88F8B9 /* NSObject+KiwiStubAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = F143E90D486F63985C039631 /* NSObject+KiwiStubAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		04D102C6E0EAF455236101DD /* KWGenericMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B56A5DBD79C00A37FBF1674 /* KWGenericMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		05C99878E8FD9517D02C4076 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D5C9C6007FD154C2964D3D2 /* Security.framework */; };
+		06B185ECD0991AEBDAADB1B0 /* KWAllTestsSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B936D8CB942A5A56CD2976A /* KWAllTestsSuite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		06D2AED64FCA70C6C179DF8F /* KWExampleNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 733E69147B12A91C3D2F7469 /* KWExampleNode.h */; };
+		073956915AC0595235BC4266 /* KWCaptureSpy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C6885FE1918B1D5FCCB5BD3 /* KWCaptureSpy.h */; };
+		09A31D061AD02E2E4DCFEC98 /* KWProbePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D6991BB531EED14CE12034 /* KWProbePoller.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		09DEA89E36F92D4B80188420 /* NSObject+KiwiMockAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 85C7ED0C4428EF79DDFA27D2 /* NSObject+KiwiMockAdditions.h */; };
+		0A4F38369EA3A3212B75EFAB /* KWMessageTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F82CE9C50DE2EB5D6275BFF3 /* KWMessageTracker.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		0AF97B2AFC936256D71F8583 /* KiwiBlockMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5547E8946415BCFF2687C3FB /* KiwiBlockMacros.h */; };
+		0C8113334CC68F2E5E750BB9 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 26616A12D74485DD7F35AFC3 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */; };
+		0CA98271D5849DC0353C406E /* KWExpectationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F2D768E9521D4DAD42E11A /* KWExpectationType.h */; };
+		0D36DBACBAD34C969F696D60 /* KWBeforeAllNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 6714CE962A2745BAA0576AEF /* KWBeforeAllNode.h */; };
+		0E33B20300E8C3B3B4F05C30 /* KWStub.h in Headers */ = {isa = PBXBuildFile; fileRef = B10DFB26BF441674BF454A31 /* KWStub.h */; };
+		0E48FE9B008510DF9E21EF65 /* KWContainStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 72B7B71AE14FD98605BA7FD1 /* KWContainStringMatcher.h */; };
+		0E8F17FE02F91AED96DEEAC2 /* HNKGooglePlacesAutocompleteQueryResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A04A85A4AF45E09211D05F7 /* HNKGooglePlacesAutocompleteQueryResponse.m */; };
+		0F5FB65F16266036EE3E98FE /* KWExampleSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = EE678E462836A712323417D0 /* KWExampleSuite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		10E7337DEEDA98273FB66B7B /* HNKGooglePlacesAutocompletePlaceSubstring.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F1A003FBAE439D59C5416B /* HNKGooglePlacesAutocompletePlaceSubstring.h */; };
+		11EF73482EA1088E3A7D19F2 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0820F16F80DF639DAEF75CBC /* AFHTTPRequestOperationManager.m */; };
+		11F8BB44321A3CB95BD01F3A /* KWExampleSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 76ABD82BC4AEB8CA257C99AD /* KWExampleSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		13627F7D0DDB8F9DD37338F7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9048A10A71BE7350762E5699 /* CoreGraphics.framework */; };
+		1403AE40AE3CA9902FCE8657 /* KWBeMemberOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C09740098CB0ED04CF0EF8D /* KWBeMemberOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		15CE7F215A47F66CFEBBBD27 /* KWFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 082B0A7B4F1A3D04E393E7A0 /* KWFormatter.h */; };
+		1638B24CECC3B025A07832F4 /* MTLReflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2217CC03D3430D9508A8B50E /* MTLReflection.h */; };
+		1696C55FF62281365ADA75DD /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB837219F4642C7538C4B31 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */; };
+		16E75DB1E7BA2C3DB8D32B02 /* MTLValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 83145D49F73F827A91190911 /* MTLValueTransformer.h */; };
+		18106747F28DFDF878CD7BDC /* KWBeSubclassOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B97D087AB1CBFC2AE12B6E8A /* KWBeSubclassOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		198C0BEF2A9791EE76477667 /* KWMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6875F04EABC52730FF7ED0B7 /* KWMock.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1AEF02B141753F1A9560821F /* KWBlockRaiseMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DE08483D913F364A4B88314 /* KWBlockRaiseMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1B0707D48BD79CA5673A938F /* KWMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 7155218DCB2550B1CEE2AB69 /* KWMock.h */; };
+		1B914C8C74DF2BC525D5DB9D /* KWBeZeroMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 09F2B9ACCA75884893CEB73C /* KWBeZeroMatcher.h */; };
+		1BB73F9C76D26B0C190597F8 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0849B79997BC56E6E1F320CA /* SystemConfiguration.framework */; };
+		1C77438731520FF4FCB98D91 /* KWBeWithinMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E5F823084A1FBC33E9F0872C /* KWBeWithinMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1CAEDE2BD5B845FB900B1278 /* KWMessagePattern.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E738B32D1B7A76E18A36D2 /* KWMessagePattern.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1E7739D0448F046E080DBC74 /* HNKGooglePlacesServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF59C17EC4BA068CDDC0EE6 /* HNKGooglePlacesServer.h */; };
+		1E8D413AAD063F53D6F9B2F7 /* KWAfterAllNode.h in Headers */ = {isa = PBXBuildFile; fileRef = C725026B8D6C6812560B24FE /* KWAfterAllNode.h */; };
+		2133DEB6A315A2772A027437 /* NSDictionary+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F578B61DB81E4DA73EC94D7 /* NSDictionary+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		219BD084081000C266D0E9F2 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 40EAB20C2A9D2282510B5C57 /* AFNetworkActivityIndicatorManager.h */; };
+		22D3E8BD002B51386F1C6C5F /* KWValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A685B442042426996D1B790 /* KWValue.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		231684C89567B45C506A1D36 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F3358E6EDDD99BDA97257D /* AFSecurityPolicy.h */; };
+		235D59747581393308215270 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B0E839C7378C0738E9E3BC6 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */; };
+		23FEAF554E5C0F0A6F1B9F6B /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 25926D5CE0A7337B84AAD14B /* UIButton+AFNetworking.m */; };
+		27BC068B9E971D9DB83A1301 /* HNKGooglePlacesAutocompleteModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BBD3815CF09824050FAD0F3 /* HNKGooglePlacesAutocompleteModel.h */; };
+		2834220C42F44D7F5928C39B /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = EAD947AD8E4E42CC4CD9CCAF /* AFURLConnectionOperation.m */; };
+		28A40FAAFFDC7D85A4AD6F63 /* KWIntercept.m in Sources */ = {isa = PBXBuildFile; fileRef = C68045EBC5A99E5C108F24C6 /* KWIntercept.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		28C95AFDA5B04B5A12CD7190 /* KWDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 44218131D89E3B1FC9D5A09B /* KWDeviceInfo.h */; };
+		2BB8BF14FEA31A4822AF9603 /* UIAlertView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CC29ACC246DA6F7E1F67EFC /* UIAlertView+AFNetworking.h */; };
+		2D610282B0D7D764B76CF049 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EDBB25B482BC397819DA2B6 /* UIProgressView+AFNetworking.h */; };
+		2D853DB923AE6517F68CCDCC /* KWWorkarounds.m in Sources */ = {isa = PBXBuildFile; fileRef = 87FD7A0C64A9B19CC92DE663 /* KWWorkarounds.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		2E3E0CEF70E7CFBC7EED0DD3 /* HNKGooglePlacesAutocompleteModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3212FD172EC8CC8484E012F2 /* HNKGooglePlacesAutocompleteModel.m */; };
+		2EEF7469701823D89CF96D0C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		30D6A129D964A3EDE7F6A289 /* KWAny.h in Headers */ = {isa = PBXBuildFile; fileRef = 648E7639AF9E1840296F29D8 /* KWAny.h */; };
+		328750F060ACBD4BE7CDB6A6 /* KWInvocationCapturer.m in Sources */ = {isa = PBXBuildFile; fileRef = A426309C2869CC9FAC706FFF /* KWInvocationCapturer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		33022AFECA9A9BCDEA7541D0 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FD70C4363BD69C147DCB7C19 /* AFNetworkReachabilityManager.h */; };
+		33F95ECDCB179210203FB4B1 /* KWUserDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7143620875F27942A27163AC /* KWUserDefinedMatcher.h */; };
+		345BAF9A011202868BA5AD9E /* NSProxy+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = EC74E98383875E4506A5AD02 /* NSProxy+KiwiVerifierAdditions.h */; };
+		377E607E19790F7F841D2515 /* NSArray+MTLManipulationAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 527E19CCCBDEAEB120D2D375 /* NSArray+MTLManipulationAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		3787D9988D7F8B5C496A10D8 /* KWSymbolicator.h in Headers */ = {isa = PBXBuildFile; fileRef = E2C44ED22FBB9178AAA07397 /* KWSymbolicator.h */; };
+		37BF703C73AF9DE8C5B33277 /* KWMatcherFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 07BEBE406BA569F669FF4460 /* KWMatcherFactory.h */; };
+		38351128BEDC44F9EE969055 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		38AA04A9DA60C15473D7E074 /* KWConformToProtocolMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 549CC6A6E90DC4DB5E187E3F /* KWConformToProtocolMatcher.h */; };
+		38E5B050956993BDB3C3C0A5 /* NSObject+KiwiStubAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 412A1CE6E03657223EC2364C /* NSObject+KiwiStubAdditions.h */; };
+		3A35DD3BEE525B55F13DF54E /* KWRegisterMatchersNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BEC7E78E2C7E6ED7C8B56 /* KWRegisterMatchersNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		3B4E3A047D6A322775E14F21 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D6D2BA4436C9C225AE57149 /* UIImageView+AFNetworking.h */; };
+		3B97F00162765877748ACA95 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 556248D7BF1D82E692C9FD09 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */; };
+		3D0510263BAC8D7E8FD79BDF /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 57953201D1E6F7E1007483B5 /* UIKit+AFNetworking.h */; };
+		3E4FD2F7C1461493CEE040D6 /* HNKServer.m in Sources */ = {isa = PBXBuildFile; fileRef = E09E45B5C5CD1693D1E21AC9 /* HNKServer.m */; };
+		3E85337DA99609CB01E66E67 /* KWExampleSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E2CDA446D629F7EAB891CCB /* KWExampleSuite.h */; };
+		40C0C1F601987D4E8FC9BFB1 /* KWSymbolicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C5242FE5C1098CB27DC77CA /* KWSymbolicator.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		428BE6FA257DDDB74393798D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		42E3C6B75FB7C9771388C13A /* KWBeKindOfClassMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 68C09A24E35AB2ADAF91B5AA /* KWBeKindOfClassMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		46A3A13DE5A4E47D3B5F7D8E /* MTLReflection.m in Sources */ = {isa = PBXBuildFile; fileRef = FCE4CAFB2A8AD604A2301A11 /* MTLReflection.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4764AF2B319E56D7C243CB79 /* NSValueTransformer+MTLInversionAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB27E0CAF2A6DB42D5C344FF /* NSValueTransformer+MTLInversionAdditions.h */; };
+		47883EF254BF1125C4919AC1 /* KWBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = C246BD0BDD2017BFFE742136 /* KWBlock.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		47E32C9B97A8BFAB24EE6CF6 /* KWItNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E40F098BD92D7DFDD394295 /* KWItNode.h */; };
+		486C35649D01DC21FE6461FD /* KWFailure.h in Headers */ = {isa = PBXBuildFile; fileRef = E706A16A7639546A99250947 /* KWFailure.h */; };
+		488CAF2E025369675740F27F /* KWBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BEB31C64F8A1853B465370C /* KWBlock.h */; };
+		48FD973736DDB78A8B56D394 /* KWBeTrueMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = AF2F31E6BF07EA57DAF28CCB /* KWBeTrueMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4B61203AD99ED5060417ACCD /* KWVerifying.h in Headers */ = {isa = PBXBuildFile; fileRef = E685C07400862F0C43753B6F /* KWVerifying.h */; };
+		4B9867ECECBABA57E470039A /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 8261FF9B09EA091684208DD8 /* AFNetworking.h */; };
+		4BE954BDC38E7331AB13075E /* KWMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7202A4CC5371FC608B616698 /* KWMatchers.h */; };
+		4C4DD4F27ECE992FCEDE78DD /* NSValueTransformer+MTLInversionAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = ECFB003F2BAEFD9189A14C5F /* NSValueTransformer+MTLInversionAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		4CB6B8266BD716707F46DF0E /* KWExample.h in Headers */ = {isa = PBXBuildFile; fileRef = C5ECF20F98365807824D5A80 /* KWExample.h */; };
+		4DC50975B6C9A568A0534703 /* KWSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DF178E8FF4ACE4BCE67088D /* KWSpec.h */; };
+		4DEF7CD8F0D049880EA9BEDF /* UIAlertView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FAAAC985E41A4C51982669F /* UIAlertView+AFNetworking.m */; };
+		4DFA305BF22B93C838B80B22 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 552DBDE7DCDDC365C46EE3CC /* UIRefreshControl+AFNetworking.h */; };
+		4E0D7BC53C507859E299BE58 /* Mantle.h in Headers */ = {isa = PBXBuildFile; fileRef = A18399ECE4AFBFE094A610CA /* Mantle.h */; };
+		4FBE51DED310F222380FFCBF /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B0F593C56E23FB94DA5595 /* AFNetworkReachabilityManager.m */; };
+		50B174B430925F4C32E60510 /* KWStringPrefixMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 10EDB71B91B02F2A1BD684D0 /* KWStringPrefixMatcher.h */; };
+		51A54A38E3624C07EAB91B55 /* KWPendingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 672941BAEBA7C288214F67CB /* KWPendingNode.h */; };
+		53BDAC696D282AC7EE789B25 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = CEDAB7C76B23C7810E2BB464 /* UIRefreshControl+AFNetworking.m */; };
+		5485BA8E48EFD8C73D43291E /* KWAfterEachNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AD2DCFCB40D91C3836479BE /* KWAfterEachNode.h */; };
+		552D9A52A254F2B2DE86DEC6 /* NSNumber+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AA082184C08EE4AC2B11DB1 /* NSNumber+KiwiAdditions.h */; };
+		56571B9CA917B469CC7E2CD3 /* KWBeZeroMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8689A6EB65C152EC31D9351B /* KWBeZeroMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		565E62B3F4FC3F3C5CE53543 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EFB6B59B47D52A12A40191A /* AFNetworkActivityIndicatorManager.m */; };
+		57DFE5B12128BAC63FE399EF /* Kiwi.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7D0076E69942EF861C830B /* Kiwi.h */; };
+		583801CD7D95360E29D1022A /* MTLModel+NSCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = EECEAC192D4F7CFCBE45E6D8 /* MTLModel+NSCoding.h */; };
+		59987A829FC4320EC7204828 /* KWAsyncVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 73EB38A2BAC393BD701C1DEC /* KWAsyncVerifier.h */; };
+		5B031095627440B91F521735 /* KWGenericMatchingAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BB55FEA6D2072567D92439A /* KWGenericMatchingAdditions.h */; };
+		5B0F4F580A6B5FC325508224 /* KWStub.m in Sources */ = {isa = PBXBuildFile; fileRef = D56A58B71A5EACA5D252F3B2 /* KWStub.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		5B183FE2CB6F0683DDC29C94 /* KWContainMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C87B40101D918DBE3560083F /* KWContainMatcher.h */; };
+		5BA134667CAC4C49845113A2 /* KWStringUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBA83830116B5FB194FAA1E /* KWStringUtilities.h */; };
+		5C4661291AB67A7A08C11DD2 /* HNKGooglePlacesAutocompletePlaceSubstring.m in Sources */ = {isa = PBXBuildFile; fileRef = 61C1663E2160FAA98037DE6A /* HNKGooglePlacesAutocompletePlaceSubstring.m */; };
+		5CD23C552D260E40ED62B390 /* KWHaveMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FE37FBCA3F0F2B03324323A /* KWHaveMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		5D5C7E0B666DAFDD5F003696 /* KWHaveValueMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = BD3B5C6C5E858E10AD8375E7 /* KWHaveValueMatcher.h */; };
+		5EC697980ABFE9EE8032569F /* KWHaveMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = CE5F9399F060572F99866945 /* KWHaveMatcher.h */; };
+		5F4D2852ECBB70FE29196013 /* NSObject+KiwiSpyAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C6AACF1C5AF6C2F26A88ADF9 /* NSObject+KiwiSpyAdditions.h */; };
+		612FFC4DADFF94349F91BC5C /* KWAny.m in Sources */ = {isa = PBXBuildFile; fileRef = 85440B27C3A6125225C6C922 /* KWAny.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		63550D7DCAFD042FCD5D4190 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F9AA4351CF37E9A005EA9238 /* AFHTTPSessionManager.m */; };
+		651CB2AC865F9E06C4353545 /* KWExample.m in Sources */ = {isa = PBXBuildFile; fileRef = C51E500A571D652D9BB558CC /* KWExample.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		654692F81F6024BA1DAC8381 /* KWBeforeAllNode.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB132241245662CB0C76262 /* KWBeforeAllNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		6546F235364886D7B30252D8 /* KWExampleDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B1430EC7B7A6822CEE24DA53 /* KWExampleDelegate.h */; };
+		665EA7DC315F36D9C8509D30 /* KWBeTrueMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = AE01E1A98E0603E4F08E369B /* KWBeTrueMatcher.h */; };
+		673F8BDB546A41D1357E3B39 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 010EF7A76D170571A78B65F8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		68D5803B56880374A95ACA85 /* KWContextNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 0362F1E849DC4875CFF89286 /* KWContextNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		693BCBFCC8658C1235381BA9 /* KWMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 42E473123FE91DED9D3D1D80 /* KWMatcher.h */; };
+		6C96F298368D6E51A4447F5E /* HNKServer.h in Headers */ = {isa = PBXBuildFile; fileRef = BA5924D68145C49E5C943F8C /* HNKServer.h */; };
+		6DFE093A4994B92EA4B28E24 /* KWSuiteConfigurationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF7DD1383EB27EE2167A32F /* KWSuiteConfigurationBase.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		6E4A190BDCA0AF1F595C9498 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		6ECD4C5C2A592498E712D071 /* KWNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 642C5B37B895F37327898670 /* KWNull.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		7077C68A4535778661A25C28 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B16E782834CDAA835A3AEE2A /* MobileCoreServices.framework */; };
+		70F333E771024B7F7853F16A /* MTLModel.h in Headers */ = {isa = PBXBuildFile; fileRef = FA6DF0081E492323DE15D506 /* MTLModel.h */; };
+		719061C263364EA06B0760EF /* NSObject+KiwiMockAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B1AA6A5F002A393C1173972 /* NSObject+KiwiMockAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		725C9FC15BB81AAAEB55D9DE /* KWBeKindOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF2F31246B4580FF518BA05 /* KWBeKindOfClassMatcher.h */; };
+		72885257213A12C9459DAF74 /* MTLModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DDBAFD254E5AD1C22F4B3B5 /* MTLModel.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		72E2D911C82CD608A5A794E1 /* KWLetNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B097853E62D4101D8829C5 /* KWLetNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		731682C1EE1A65FBA3FE6B44 /* KWSuiteConfigurationBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 88ACEE277F8D5693394E79D0 /* KWSuiteConfigurationBase.h */; };
+		73E56A03712BCFB1DC4E5C1B /* HNKServerFacade.h in Headers */ = {isa = PBXBuildFile; fileRef = 22E78055A602629E8E4B3C2F /* HNKServerFacade.h */; };
+		74DA91965AD93C82DD3E5B86 /* KWExampleSuiteBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 00E6BEBF7C1394A81B96155B /* KWExampleSuiteBuilder.h */; };
+		74FB080E01BA43B188E69585 /* HNKGooglePlacesAutocompleteQueryConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = D0354A1F8D5A2E496BF1F3CE /* HNKGooglePlacesAutocompleteQueryConfig.m */; };
+		7594816461EDE4A525DFCC4A /* KWProbe.h in Headers */ = {isa = PBXBuildFile; fileRef = 40150474A41CDBE269D53516 /* KWProbe.h */; };
+		76E6CDAC819838288F010557 /* KWGenericMatchEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = 500A16F2ABC6DC83680E6D2B /* KWGenericMatchEvaluator.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		76F21BD050734EC9E071AFF0 /* KWBeBetweenMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 25491BAADBFD661DD7CBA8CF /* KWBeBetweenMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		777576803A40C43E85298E69 /* KWCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B033E63CE53E620F14B1722 /* KWCallSite.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		77BCDD08450AF4D6BAC4B00A /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 979371E2DC3BCA3C1F8E9DC9 /* AFURLConnectionOperation.h */; };
+		7890E306FBDF1A2C51859F79 /* KWLetNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 40A66751315DFD2CF46319DB /* KWLetNode.h */; };
+		78F1BD0483197D6356F233C5 /* KWExistVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = C70A82B07335BBE631FC70DA /* KWExistVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		7B050014EF9100C37D14F762 /* KWObjCUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F49B6A6512CEDDBB5F3B139 /* KWObjCUtilities.h */; };
+		7B2CA14C9A7C892170FB1A43 /* NSValue+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F112277E31042594585ED74D /* NSValue+KiwiAdditions.h */; };
+		7B61433755A852218DA7C5D5 /* KWBeEmptyMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C5129A5942AD017A33AC8426 /* KWBeEmptyMatcher.h */; };
+		7D1372486C15FE773A119107 /* KWContainStringMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B72F8CC36CF3EF7BF883CD71 /* KWContainStringMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		7DB716FC793688E73FDA6078 /* KiwiMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = B7018060801AB9C046436C71 /* KiwiMacros.h */; };
+		7E99559A05360109939216F8 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 7141F71B45711513E9CDC94C /* UIActivityIndicatorView+AFNetworking.m */; };
+		7EA00273D66A544C91B3D7C6 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AF39182295F17216598BB7A /* NSInvocation+OCMAdditions.h */; };
+		7ECD7DEA60A283EAABCE59E3 /* KWStringContainsMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A19783740EEB46F94713DB /* KWStringContainsMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		7F99319E041D9899E9E1EA89 /* KWAsyncVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 832416BFE0EAE3B092938115 /* KWAsyncVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		808C0405D476412614B0347B /* KWBeMemberOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A53DAAAF8D2724A47AE6831 /* KWBeMemberOfClassMatcher.h */; };
+		80A7F0B003732504E7C21E7D /* KWMessageSpying.h in Headers */ = {isa = PBXBuildFile; fileRef = 281BA20036AA57DBA9A1AF9C /* KWMessageSpying.h */; };
+		82A8E878274A26D7A99F5087 /* HNKGooglePlacesAutocompleteQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 010243B947001D659539D13C /* HNKGooglePlacesAutocompleteQuery.h */; };
+		83005DC3672DDE1E56E49169 /* HNKGooglePlacesAutocompletePlaceTerm.h in Headers */ = {isa = PBXBuildFile; fileRef = 227F1CA02855AA44E3F2CA53 /* HNKGooglePlacesAutocompletePlaceTerm.h */; };
+		839B9EACFCCD71A14DCFC507 /* KWBlockNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D1B81239511CEE949C339D0C /* KWBlockNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8588DE2F8A1D92854BA59469 /* NSError+MTLModelException.h in Headers */ = {isa = PBXBuildFile; fileRef = CFBCE7C2CB68A01857DD0A64 /* NSError+MTLModelException.h */; };
+		85B7ED1263EB7CC0127526B2 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 93747B5D2398EB141394C75C /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		86186248A47DD1E5E16E485A /* HNKGooglePlacesAutocompleteQueryResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD71CD7B5300FD2ADFE8A2A /* HNKGooglePlacesAutocompleteQueryResponse.h */; };
+		86D5233C5DF4E2248C775C3E /* KWFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F57C5A7D2D81698AB8BC3015 /* KWFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8748720DCD239DC70CCA5D47 /* KWMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 31582A72A256A5F5579C40BC /* KWMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8827A80B6314BC8FC62ADBEA /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EA061D9CAE43EE7F7CCE08A7 /* metamacros.h */; };
+		88BA31B394D17E91E8217E46 /* KWStringContainsMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E6CE5E5C0DF10ABD47EE09F /* KWStringContainsMatcher.h */; };
+		88ED6D75A0DE9A49115A7959 /* KWRegularExpressionPatternMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9214CD0A612664E006226CD3 /* KWRegularExpressionPatternMatcher.h */; };
+		88F830BF21864CC177139925 /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 49EF17E0F1C2B8E07C24A8AE /* UIButton+AFNetworking.h */; };
+		89AFCD9569CE720A3B11FD0D /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CE46019B390E97F8DF7EA63 /* AFHTTPSessionManager.h */; };
+		8A06163F924BF6F475FD3BAF /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 12268B1FAAF4DD67D8F90ED3 /* AFURLRequestSerialization.h */; };
+		8A25711CBB2B09B8BD1A2136 /* CLPlacemark+HNKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1BF96547435A8130BC87F3 /* CLPlacemark+HNKAdditions.m */; };
+		8B88783B28AFDF02855B0220 /* KWChangeMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E14587827A8C3CC6C35538 /* KWChangeMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8BF9CD35E6B1FFE10EDD308C /* KWProbePoller.h in Headers */ = {isa = PBXBuildFile; fileRef = F695E5FD177B4B9EDDD99322 /* KWProbePoller.h */; };
+		8E40912B9E1D83649BE9F462 /* NSProxy+KiwiVerifierAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F19D47C11FB1B1D3A48D833 /* NSProxy+KiwiVerifierAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		8F1798BD4D0189AF7E7B8087 /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CB6EEF5F9A19D94E64AF682 /* AFURLResponseSerialization.m */; };
+		910FFE685DEC2FB272590FD6 /* KWInequalityMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A7D5BBC2D95B105E40727D /* KWInequalityMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		929785D5C80A7D5C165F6358 /* KWItNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A72E3B0CDBD39D96F700573 /* KWItNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		933B240DCF52DC58D00565C2 /* KWNull.h in Headers */ = {isa = PBXBuildFile; fileRef = E1F0E450100A8B8451D13A32 /* KWNull.h */; };
+		9478C7C5159399C0B610D975 /* KWUserDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B715902432199163C644C9C /* KWUserDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		956B487E02CCC97C5D559C01 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = ADACF9CDCD8D0F37A34CEEE4 /* AFHTTPRequestOperation.m */; };
+		96C0467B97DDF2EFA474E5ED /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BF3B00A9B5261E8F00DCAD73 /* UIImageView+AFNetworking.m */; };
+		973EDBD1FCD780DF1BEC2594 /* KWMessagePattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 7427F066E7CC974C9AA63BEE /* KWMessagePattern.h */; };
+		974350FFF8BE6FB696E78D6F /* KWInvocationCapturer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6310F6675AF4AD7BE7692B6C /* KWInvocationCapturer.h */; };
+		97EBF2A42549A1298CB25CB7 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F9CFA70131BE2D3F63FFD61 /* UIWebView+AFNetworking.h */; };
+		9879CC5A789E5A9CFCFB3021 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = A5481AF1ECA95BFAC435F7A5 /* AFURLRequestSerialization.m */; };
+		98D214AC09EFBCBA1C6DA010 /* NSValue+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D6A97C20A6FA8F514F98C226 /* NSValue+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9971C33D28B361E705578BB9 /* KWExampleNodeVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = AB274ADFC1EDD20DFCE0EB4E /* KWExampleNodeVisitor.h */; };
+		9A6C8829E87199F399693502 /* KWRegularExpressionPatternMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B0C87521FCE58537C2E0EE76 /* KWRegularExpressionPatternMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9C881BDA11B6CEB90C96D7CD /* HNKGooglePlacesAutocompletePlace.m in Sources */ = {isa = PBXBuildFile; fileRef = E4545C08DE9A561A278D8197 /* HNKGooglePlacesAutocompletePlace.m */; };
+		9D591E5DDB9CA0ECDEB27E06 /* KWNotificationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A26E260C9799159DA7092A33 /* KWNotificationMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9DDB3263D49E8BCBE7A554EC /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5D10DF5C2F0ED786CDD31C /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */; };
+		9F2A926237FC27E5B27B5C68 /* KWObjCUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = DE28C0DC91CDAC07DE709042 /* KWObjCUtilities.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9F2DAFFBDBE6B937A9E044B9 /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CD929DAC6F4C02089D2660D /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9FCFEC2D41A771115B69FC5F /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 79451FB8991C23B35C99512A /* UIActivityIndicatorView+AFNetworking.h */; };
+		A02023D2D3A8ED91CC2BBDD2 /* KWInequalityMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A4F915DB034209E392AA4CA3 /* KWInequalityMatcher.h */; };
+		A292F25E2837CB05D2A76553 /* HNKGooglePlacesAutocompletePlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 233FEC86EFB6F219E93105A7 /* HNKGooglePlacesAutocompletePlace.h */; };
+		A3DDB1CD3D4B95FAF268FC2C /* KWGenericMatchingAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BD1FCEAA03B2F2473C5E869 /* KWGenericMatchingAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		A3F0B960106564FAE41640BA /* KWCountType.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5E9DEB1501BABA40C65EA6 /* KWCountType.h */; };
+		A4FB8917D103AB573F93DE60 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		A52F5DBEA7B9D231FA33A396 /* KWFailure.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FC592DD80FFBEB0494961E8 /* KWFailure.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		A558FC612C95B04B65B0C150 /* KWNilMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 609459F56B11A147E435C7BC /* KWNilMatcher.h */; };
+		A66A52843FEB94DF3FF111F5 /* KWGenericMatchEvaluator.h in Headers */ = {isa = PBXBuildFile; fileRef = C8224EBBC7A835A7DA27BE73 /* KWGenericMatchEvaluator.h */; };
+		A7489A082F354F2DC2EFF128 /* KWBeIdenticalToMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = ABB8D740959AD367214CCB1C /* KWBeIdenticalToMatcher.h */; };
+		A7BAFA773976B05287EB6A59 /* NSObject+MTLComparisonAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 82267DB3CB3C73201A6665A9 /* NSObject+MTLComparisonAdditions.h */; };
+		AAEA82762E393E10BCBF4F0B /* NSObject+KiwiSpyAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C6179FCBD8AEEA8636E75610 /* NSObject+KiwiSpyAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		AC56EFDC0BBD3DB70DC4EA3A /* KWIntercept.h in Headers */ = {isa = PBXBuildFile; fileRef = 6783109AFC231C57654FDCDD /* KWIntercept.h */; };
+		B0F94E03AE71CE46919CD0E2 /* KWBeforeEachNode.m in Sources */ = {isa = PBXBuildFile; fileRef = DA65AEE5BCAE9E492256C16C /* KWBeforeEachNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B15A7F08FA5DF19C9E604F22 /* KWLet.h in Headers */ = {isa = PBXBuildFile; fileRef = CCF4D2B2B1B0793E2F40EF87 /* KWLet.h */; };
+		B2A2854FE9D11C26557F8E9F /* KWRespondToSelectorMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F4787184CE58BDEA445AADAD /* KWRespondToSelectorMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B3654283E3EF4425F0A7D01E /* KWCaptureSpy.m in Sources */ = {isa = PBXBuildFile; fileRef = 722133A952407EED89644AFA /* KWCaptureSpy.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B49E13E8C7BEF24B3E45FD87 /* NSObject+KiwiVerifierAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 91D4FE8D1A36492839D2FA40 /* NSObject+KiwiVerifierAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B6D49DC7AC2AE205F45D47BD /* KWMatchVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C1E48997104B8A0CE661DE /* KWMatchVerifier.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B8E276FABADFF4C5BB2C8B67 /* HNKGooglePlacesAutocompleteQueryConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE90FCDE593FB3F346B9EF2 /* HNKGooglePlacesAutocompleteQueryConfig.h */; };
+		B90776CB2E58193243562A39 /* KWRespondToSelectorMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C0A2C1AB05CFFB7DC47385 /* KWRespondToSelectorMatcher.h */; };
+		B9E965492A7BACEEC5CDC644 /* KWEqualMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 355DEDFA5869A2C4E5BE70E2 /* KWEqualMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		BA50AAD1210F728FFE920F60 /* KWAfterAllNode.m in Sources */ = {isa = PBXBuildFile; fileRef = BD4153A19B0C1B9B18C9C291 /* KWAfterAllNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		BDE318B9D5FE435A18F1A1B1 /* KWStringPrefixMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E748C07296161769F7B1F78C /* KWStringPrefixMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		BDE70EEF3A2811B579D8994D /* KWMatchVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = C026BB0B0824CF270DF25F05 /* KWMatchVerifier.h */; };
+		BEDBB6F3E4A24084317E9136 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FB7CB2E54BF7556D6507620 /* EXTScope.h */; };
+		BFC4D7D496B55C5EE6AA038E /* NSError+MTLModelException.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D26DAE34B95815CB3975075 /* NSError+MTLModelException.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		BFE8B1B2BE0DD060C30CBB6C /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C15F918C2E0C6885A74307EB /* AFURLSessionManager.h */; };
+		C320757E7F70560B5DCF2E99 /* KWPendingNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 79AC4F574E1DE55327C639F1 /* KWPendingNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C3263C5CF976CCCB345E03D4 /* HNKGooglePlacesAutocompletePlaceTerm.m in Sources */ = {isa = PBXBuildFile; fileRef = A2539A48472FC403B1233EEA /* HNKGooglePlacesAutocompletePlaceTerm.m */; };
+		C3FF90C4F72000DDAE96D424 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		C41152A5B2F9FD3DF91B46B5 /* KWSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D39E3712995787F8D1F82DB /* KWSpec.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C45174A90BE17123510D7CF5 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 66DEAEF269DC1D1A4F91E3D5 /* AFURLSessionManager.m */; };
+		C813EF9514EA80AB339A2DB9 /* KWContextNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A3381FFD966F8078306796A /* KWContextNode.h */; };
+		C9E33DC28F651B846506BC21 /* KWNilMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 37318A03ABD30BF24418AC75 /* KWNilMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C9FBF78154097D459605C0BD /* KWChangeMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 292F2E33DDFAE0DC4004FC29 /* KWChangeMatcher.h */; };
+		CA968517A0BBA6E1B6DA0E69 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = A1BA14C28082DEBAA8A2C0D3 /* AFSecurityPolicy.m */; };
+		CBF1DE2111F3A80F060DC196 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 29E19316023814B3DF17CC6C /* AFURLResponseSerialization.h */; };
+		CC52B85A7FF9E61E59D41B44 /* KWCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE8ECEF2A2E1B6EBCF26FBA /* KWCallSite.h */; };
+		CC64466EE76A3D0EB2FEB842 /* KWBeBetweenMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = EB9D5E32969C075AF7602E44 /* KWBeBetweenMatcher.h */; };
+		CCBC4A54FD4C9B2861845CD1 /* MTLJSONAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = B275B49BD82B42FBB1AC384B /* MTLJSONAdapter.h */; };
+		CCC1C6958039D56D8F5A1591 /* KiwiConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = BFB415FBCBBCD15E98C25BA2 /* KiwiConfiguration.h */; };
+		CCD6D77154C416393D67112F /* NSMethodSignature+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F844BBF4F25054BEC88197CA /* NSMethodSignature+KiwiAdditions.h */; };
+		CCF89CE397BB63A25A5D01E9 /* KWBeEmptyMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F4F3F6D856E0B9DC7101F9C6 /* KWBeEmptyMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CD4FBCA2E828F0EDB2159B8E /* KWFutureObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 228B9B1BEBC410181B0E354D /* KWFutureObject.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		CE222BEC54B40B86E22E9496 /* KWReceiveMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B0D49FF0C2E69758A6F0A435 /* KWReceiveMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		D0CAE87B31D527BFE871A379 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07452410253F30793CC25F31 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */; };
+		D1A9E19EDFC64BABACD86551 /* MTLJSONAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = FBBD71D5F2DD9BA199F190F7 /* MTLJSONAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		D277EBCB4E8066C46D9525D6 /* NSInvocation+KiwiAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EB13C6A3EC95EC04FB86C0F /* NSInvocation+KiwiAdditions.h */; };
+		D757B476DE0F9831420E7556 /* HNKGooglePlacesAutocomplete.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B8FDEEB3D678AAEFBB7B5EE /* HNKGooglePlacesAutocomplete.h */; };
+		D9DC6A2E15F52E58D684F5BF /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1600E36AE9638A28927580CA /* EXTRuntimeExtensions.h */; };
+		DA137EC3CEFEAA3274E5BBA8 /* KWGenericMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B3971D7A328368B1EFDABA2 /* KWGenericMatcher.h */; };
+		DABA649E4F58AC99F5F505D4 /* KWNotificationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4422846B47EAB643E3520E1C /* KWNotificationMatcher.h */; };
+		DB883C466CBC44AB3487F861 /* MTLManagedObjectAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C0909B2DEB2A012C7D90EFE /* MTLManagedObjectAdapter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		DD44E52E962B0771F111DC07 /* KWAfterEachNode.m in Sources */ = {isa = PBXBuildFile; fileRef = B29016C0A3DFEA6B205E6EAD /* KWAfterEachNode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		DD53596BB31F0785727A76E9 /* KWWorkarounds.h in Headers */ = {isa = PBXBuildFile; fileRef = D1ADE9D07A80471786246DAA /* KWWorkarounds.h */; };
+		DDA0EE9454AD57448BA1ACC8 /* KWFutureObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E45A735D023A120B193A4D /* KWFutureObject.h */; };
+		DF5887CFF1C2BDDA3D9BD47F /* NSDictionary+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 69DBFCE1E3C8DC198EBF4C70 /* NSDictionary+MTLManipulationAdditions.h */; };
+		DF62D9815043F7157E803A76 /* KWBlockRaiseMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0B97615587ECBE1931B49 /* KWBlockRaiseMatcher.h */; };
+		DFE94C593973476C4537E887 /* KWBeWithinMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 1052FAC22AA67AF2EC36D7E2 /* KWBeWithinMatcher.h */; };
+		E0B8604760A6179FABD221D2 /* NSArray+MTLManipulationAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B51820D96C5D0E156605C33C /* NSArray+MTLManipulationAdditions.h */; };
+		E1197D91C6A0CAC999AC43BF /* KWValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4934A9E5653138F02A72E15F /* KWValue.h */; };
+		E192E1F3ABCB77E39E076B3A /* CLPlacemark+HNKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B93B3747BF28C0DC7F495048 /* CLPlacemark+HNKAdditions.h */; };
+		E1D3C1F048B787BC03DEA100 /* KWMatchers.m in Sources */ = {isa = PBXBuildFile; fileRef = 4107BE41A34681EEC76F2005 /* KWMatchers.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E1EDDA3E2A44B8FCD777E25F /* MTLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = A34FFD6DE4AB76C387CC95CD /* MTLValueTransformer.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E2A8660F36DDBE785BA1502A /* NSObject+MTLComparisonAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B88B0754D37D90A3EB09B37 /* NSObject+MTLComparisonAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E2B250701DB2C10F82264A9D /* KWBeSubclassOfClassMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 81D01AC5EC422EFF65314554 /* KWBeSubclassOfClassMatcher.h */; };
+		E3A7A455EB5A2EED3FD75481 /* NSNumber+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4841DA8221B6D68DA8732C2C /* NSNumber+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E4EBF0E5FA2B9C5D6164D4D0 /* KWMatching.h in Headers */ = {isa = PBXBuildFile; fileRef = 4137EDD51DDC99D208F718F9 /* KWMatching.h */; };
+		E51F463DBE15D0FE5467F648 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = D8ED5C06FB8AA26D350BF759 /* UIWebView+AFNetworking.m */; };
+		E52211B4C42F38394474C29A /* KWDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = EF1EF0A919CA66089DEFCE42 /* KWDeviceInfo.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E5AE603D0A8C7ED90695CC38 /* MTLModel+NSCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 983927CAAFCC097DA87D8147 /* MTLModel+NSCoding.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E8C55E5D02B22F96EBA612F3 /* KWReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = D432B5A3263BFD43852C7632 /* KWReporting.h */; };
+		EAE04019B282FD5688A9CA61 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 681D36712B129F452C828D4F /* AFHTTPRequestOperation.h */; };
+		EC190C7D6BFE73D642288E29 /* KWContainMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C4EB6F8BD01AFDDC98B7B60D /* KWContainMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		ECF6208532B1C74DAD23C3F0 /* MTLManagedObjectAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ACAE2CA1D731030F14985F4 /* MTLManagedObjectAdapter.h */; };
+		ED1EFD93328EF5534F2A0295 /* KWBeIdenticalToMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 721B7DF2174B45CD235D4BDC /* KWBeIdenticalToMatcher.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		ED4CF39BA34F30831443EDEA /* KWRegisterMatchersNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 255B6246724D372E0C784913 /* KWRegisterMatchersNode.h */; };
+		EE3584BEE639300F1ADB5359 /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = AD657064F8AF2E5C24290147 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		EE6469D34FAD9B88A422D157 /* HNKGooglePlacesServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 40793574779A3C35386709EB /* HNKGooglePlacesServer.m */; };
+		EF97163AA02728C65E16B8D0 /* KWBeforeEachNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 76201B007C317EF01040913A /* KWBeforeEachNode.h */; };
+		F125F0CDCBBA30193AFC6D39 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 06641A7F1991A534516CFC29 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */; };
+		F135DBC98A27E9FBCCF7F036 /* NSObject+KiwiVerifierAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F2EC69AA85ADAAB1B04F70D8 /* NSObject+KiwiVerifierAdditions.h */; };
+		F2BD70343CEBA0A855677E65 /* KWStringUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0918F41F27FEA1BCFF783F /* KWStringUtilities.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		F380A90C1557D846A03F232A /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 885E4D24A736984173D49371 /* EXTKeyPathCoding.h */; };
+		F4819F8A5E0BD3E138C8C375 /* KWMatcherFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 979AA37F4938B3003CE4D352 /* KWMatcherFactory.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		F5D7CBACA9FD102DFCF28A0A /* KWExistVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = C907D7980FC98B5B5B565692 /* KWExistVerifier.h */; };
+		F5DE2EC70F9E10767AA0A1AA /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E473DF1FB362FD896BAAD5F7 /* UIProgressView+AFNetworking.m */; };
+		F64A653EF051FD95390F6E79 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B21D11C3694710193BFFF4 /* Foundation.framework */; };
+		F79144976EDEF0BD93A1B68F /* AFHTTPRequestOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E2AE3B9FB94EE7E53A3159F /* AFHTTPRequestOperationManager.h */; };
+		F847DC3FA76CF48FE6FA466F /* KWEqualMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 105D446E4751C4E31439EE7A /* KWEqualMatcher.h */; };
+		F868BA664B5EC8A5D743BBEC /* KWBlockNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 87FE19C4EF4405A7CA75D53D /* KWBlockNode.h */; };
+		F8EAFF5E395000E2B6509934 /* HNKGooglePlacesAutocompleteQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = D20A6E820FE0F89BCCD20879 /* HNKGooglePlacesAutocompleteQuery.m */; };
+		F9E17CF2E14BD16E04AD9254 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AB4D15FAD0279C2A6C3C934 /* XCTest.framework */; };
+		FAC6F95A0713ABF4B1830844 /* KWMessageTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 08824E825A6719898C23256D /* KWMessageTracker.h */; };
+		FC405EC038C374680BBC867F /* KWReceiveMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4181F501C93565E53918C60E /* KWReceiveMatcher.h */; };
+		FE15B862A08501CEDC3AF3DA /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 52ECC1CB169F733F4FFD21C4 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */; };
+		FED519B05E68FD03951236F5 /* NSInvocation+KiwiAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C30D1A79D9BD7E9E7B11F72E /* NSInvocation+KiwiAdditions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0C2B8A7662FAB771D3A31CD5 /* PBXContainerItemProxy */ = {
+		028C44442DF5F6FB721AD81D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5D03E40D2B206B4F0239D0B3;
-			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
-		};
-		4440FA45F903C56AE32EA26F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8AB39843A51D427DA606B574;
+			remoteGlobalIDString = 5F8653000638B4C4125103D7;
 			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
 		};
-		450D4A79C2E8051B5A3FE3AB /* PBXContainerItemProxy */ = {
+		4EF97B0E8573C8CE373E1E80 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 542726CE34D02AF7E45A9996;
-			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
-		};
-		6D5D2A7904667C53ED4F70E3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5D03E40D2B206B4F0239D0B3;
+			remoteGlobalIDString = 6498242C45A38780A3C09F81;
 			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
 		};
-		6E13547794EADD2A6DC4E511 /* PBXContainerItemProxy */ = {
+		53ACEA9AC7FBBCB5539B2F5C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C0B3D285938CDBD7C09C3320;
-			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
-		};
-		9C1D124292920D8FA8ACB0CB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 220B5C0ED3A2349694FDC974;
+			remoteGlobalIDString = C000419035B9E6734FF11DAF;
 			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
 		};
-		A71FF503C0D29110C2FAFD6A /* PBXContainerItemProxy */ = {
+		5BEC5D19BADF1BD2841AE887 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C0B3D285938CDBD7C09C3320;
+			remoteGlobalIDString = CF63059F21D3520300C09AD3;
+			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
+		};
+		D3FC0999F17A175F3B09D954 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3980640E62AEEFF342677376;
 			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
 		};
-		FC927634987E7FA1B8AAA422 /* PBXContainerItemProxy */ = {
+		E23DA2EBBB1DC9D5F6F2FBBE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6693617DAA1242D75F0C3B4F /* Project object */;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 220B5C0ED3A2349694FDC974;
+			remoteGlobalIDString = 6498242C45A38780A3C09F81;
+			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
+		};
+		E51C19C0ACCCA64C2B452CB0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C000419035B9E6734FF11DAF;
 			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
+		};
+		F51A5CD6C5BA57FDA8E63E88 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 15402930F01A4867F7C30448 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3980640E62AEEFF342677376;
+			remoteInfo = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01D809459B07EADC892EE1FE /* KWExampleNodeVisitor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleNodeVisitor.h; path = Classes/Core/KWExampleNodeVisitor.h; sourceTree = "<group>"; };
-		0211BCFAE34E1F9DB9A3CC67 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m"; sourceTree = "<group>"; };
-		022B28936154FE99F6751FF9 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m"; sourceTree = "<group>"; };
-		02ABA1AEC8FD8F076DF71180 /* CLPlacemark+HNKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CLPlacemark+HNKAdditions.m"; path = "Pod/Classes/CLPlacemark+HNKAdditions.m"; sourceTree = "<group>"; };
-		02EBE93F5FBD04BF5E534711 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
-		03A8689EE008D2033279A20F /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m"; sourceTree = "<group>"; };
-		03FEAF0F394038598BB17F37 /* KWAfterEachNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAfterEachNode.m; path = Classes/Nodes/KWAfterEachNode.m; sourceTree = "<group>"; };
-		06BEC211E8353D3230D0118F /* KWItNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWItNode.m; path = Classes/Nodes/KWItNode.m; sourceTree = "<group>"; };
-		06E43F49A15467BD4BDD8D11 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
-		081392ADF38F84C71A2393EF /* AFHTTPRequestOperationManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperationManager.h; path = AFNetworking/AFHTTPRequestOperationManager.h; sourceTree = "<group>"; };
-		08CAC1432EACEAF9C7EC6598 /* KWBlock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlock.m; path = Classes/Core/KWBlock.m; sourceTree = "<group>"; };
-		09792AC14685E9D04E440D77 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		09CD708AB37C53F8AED75CE5 /* HNKServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKServer.h; path = Pod/Classes/HNKServer.h; sourceTree = "<group>"; };
-		0A439E08AA80A119515B78C7 /* KWVerifying.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWVerifying.h; path = Classes/Verifiers/KWVerifying.h; sourceTree = "<group>"; };
-		0A9BB0416EFA7222D95EE2DE /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		0AC2545C01C2D38918B3134F /* KWPendingNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWPendingNode.h; path = Classes/Nodes/KWPendingNode.h; sourceTree = "<group>"; };
-		0B2335F35CEF26E2D86EC55C /* KWBeBetweenMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeBetweenMatcher.m; path = Classes/Matchers/KWBeBetweenMatcher.m; sourceTree = "<group>"; };
-		0BAC523455A5CD50A0D5B29B /* KWConformToProtocolMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWConformToProtocolMatcher.m; path = Classes/Matchers/KWConformToProtocolMatcher.m; sourceTree = "<group>"; };
-		0C995D56AEAEED4FCECD748D /* KWSymbolicator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSymbolicator.m; path = Classes/Core/KWSymbolicator.m; sourceTree = "<group>"; };
-		0D88BD24E3CB4EF42A100E63 /* KWRegisterMatchersNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRegisterMatchersNode.h; path = Classes/Nodes/KWRegisterMatchersNode.h; sourceTree = "<group>"; };
-		0E5CAE219A18BD25491B34C9 /* NSObject+MTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MTLComparisonAdditions.h"; path = "Mantle/NSObject+MTLComparisonAdditions.h"; sourceTree = "<group>"; };
-		0F6A0D801C8E6AF4B4842636 /* KWFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFormatter.m; path = Classes/Core/KWFormatter.m; sourceTree = "<group>"; };
-		0FA75141F2FF010DCD49371F /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		1046E623ED4FE1E6EA3E951E /* AFHTTPRequestOperationManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperationManager.m; path = AFNetworking/AFHTTPRequestOperationManager.m; sourceTree = "<group>"; };
-		107602048702D57484FD8190 /* NSValueTransformer+MTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLInversionAdditions.h"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.h"; sourceTree = "<group>"; };
-		129389ACC98F2328B0CDD865 /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+MTLManipulationAdditions.h"; path = "Mantle/NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		1611DC102473CCFCF15BDD60 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
-		16F2D9EBD8FFF3D5438D6C98 /* KWCaptureSpy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWCaptureSpy.m; path = Classes/Core/KWCaptureSpy.m; sourceTree = "<group>"; };
-		17353691FAE342F2D70571D7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		184016CFBC5E5B9083FE35E6 /* KWSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSpec.m; path = Classes/Core/KWSpec.m; sourceTree = "<group>"; };
-		1959B391BB85A87DBB5808E1 /* KWReporting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReporting.h; path = Classes/Core/KWReporting.h; sourceTree = "<group>"; };
-		1B475A6A05A55309B0F7EC7D /* KWLetNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWLetNode.h; path = Classes/Nodes/KWLetNode.h; sourceTree = "<group>"; };
-		1B56B7287056FCCAA2F25B2F /* KWMock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMock.m; path = Classes/Mocking/KWMock.m; sourceTree = "<group>"; };
-		1BA8719D40386993EDBC3C32 /* KWUserDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWUserDefinedMatcher.m; path = Classes/Matchers/KWUserDefinedMatcher.m; sourceTree = "<group>"; };
-		1BE89C7599E344BA6D699F26 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		1C9271E5E05D8D5FAC09ACA7 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m"; sourceTree = "<group>"; };
-		1CC1E1865FB80ADFE9A30171 /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Classes/Core/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
-		1D70C4E6E0D4654EF0E96309 /* KWExpectationType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExpectationType.h; path = Classes/Core/KWExpectationType.h; sourceTree = "<group>"; };
-		1D99D6813A6071660B5ED853 /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1EEFAA1C931954784B29D904 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig"; sourceTree = "<group>"; };
-		1FE9734F16C3F2C0F3934E62 /* NSDictionary+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLManipulationAdditions.h"; path = "Mantle/NSDictionary+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
-		200F3ADB42262CE3D6662BAD /* HNKServerFacade.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKServerFacade.h; path = Pod/Classes/HNKServerFacade.h; sourceTree = "<group>"; };
-		2039C37E5E178A4721FCAEEC /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
-		21B804FF6359C43EE980E650 /* KWBeTrueMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeTrueMatcher.h; path = Classes/Matchers/KWBeTrueMatcher.h; sourceTree = "<group>"; };
-		22CC793150A8EF06060FA75D /* KWContainStringMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContainStringMatcher.m; path = Classes/Matchers/KWContainStringMatcher.m; sourceTree = "<group>"; };
-		22D05E3531D5FF919FC6E6DA /* HNKGooglePlacesServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesServer.m; path = Pod/Classes/HNKGooglePlacesServer.m; sourceTree = "<group>"; };
-		234C512D375240E8494F169F /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = Mantle/extobjc/EXTScope.m; sourceTree = "<group>"; };
-		23A2F940EAADF93E81371E40 /* KWHaveMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWHaveMatcher.h; path = Classes/Matchers/KWHaveMatcher.h; sourceTree = "<group>"; };
-		253C84B24CB86C566DDB3CFC /* KWDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWDeviceInfo.m; path = Classes/Core/KWDeviceInfo.m; sourceTree = "<group>"; };
-		27A3B3749CA6F3E5BC0A7E4B /* UIAlertView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+AFNetworking.h"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.h"; sourceTree = "<group>"; };
-		287266DB1819F9E456C3FC0D /* KWUserDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWUserDefinedMatcher.h; path = Classes/Matchers/KWUserDefinedMatcher.h; sourceTree = "<group>"; };
-		290DD89F0E22EC1A8423CFF6 /* MTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLJSONAdapter.h; path = Mantle/MTLJSONAdapter.h; sourceTree = "<group>"; };
-		29E999622A0EFB0F197D3F35 /* KWAny.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAny.m; path = Classes/Core/KWAny.m; sourceTree = "<group>"; };
-		2B18D2EF337057F72769C5E9 /* KWProbePoller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWProbePoller.m; path = Classes/Core/KWProbePoller.m; sourceTree = "<group>"; };
-		2CAEFCE0CAE766967FF57CCE /* KWBeforeEachNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeforeEachNode.m; path = Classes/Nodes/KWBeforeEachNode.m; sourceTree = "<group>"; };
-		2E30C9D4AACB91267C2BD9B4 /* KWRegularExpressionPatternMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRegularExpressionPatternMatcher.h; path = Classes/Matchers/KWRegularExpressionPatternMatcher.h; sourceTree = "<group>"; };
-		2E90E538D7145B39D065ABF2 /* KWInvocationCapturer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWInvocationCapturer.m; path = Classes/Core/KWInvocationCapturer.m; sourceTree = "<group>"; };
-		2EA291BF1BE9F258FBB14DD6 /* KWBeforeAllNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeforeAllNode.h; path = Classes/Nodes/KWBeforeAllNode.h; sourceTree = "<group>"; };
-		2F438AB2D67392E51FC356C0 /* KWMessagePattern.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMessagePattern.m; path = Classes/Core/KWMessagePattern.m; sourceTree = "<group>"; };
-		2F52229D35D28DCA6AB72158 /* KWCaptureSpy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCaptureSpy.h; path = Classes/Core/KWCaptureSpy.h; sourceTree = "<group>"; };
-		31930C210523BAC4C36DF829 /* KWBeforeEachNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeforeEachNode.h; path = Classes/Nodes/KWBeforeEachNode.h; sourceTree = "<group>"; };
-		31AE1E9B659989B3DE90BBFF /* KWStringUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringUtilities.h; path = Classes/Core/KWStringUtilities.h; sourceTree = "<group>"; };
-		31D6F826354B442AB08808D9 /* HNKGooglePlacesAutocompleteQueryResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQueryResponse.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryResponse.h; sourceTree = "<group>"; };
-		32199018EA77754E2EB30C81 /* NSNumber+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNumber+KiwiAdditions.h"; path = "Classes/Core/NSNumber+KiwiAdditions.h"; sourceTree = "<group>"; };
-		32411DCB52B723A95472F760 /* NSProxy+KiwiVerifierAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSProxy+KiwiVerifierAdditions.h"; path = "Classes/Core/NSProxy+KiwiVerifierAdditions.h"; sourceTree = "<group>"; };
-		32BF47213CD680B37BAAF08F /* Pods-HNKGooglePlacesAutocomplete-Example-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-environment.h"; sourceTree = "<group>"; };
-		339EB1AC3F31B193AC74A33D /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		34AA9B9583960E51EB1596A8 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
-		34BD9DE5DACB106274358294 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
-		34F6ECC50122BB8D15313895 /* KWBeTrueMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeTrueMatcher.m; path = Classes/Matchers/KWBeTrueMatcher.m; sourceTree = "<group>"; };
-		35B4E4E6A0D37E4D4C2F6CB3 /* KWMessageTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMessageTracker.m; path = Classes/Core/KWMessageTracker.m; sourceTree = "<group>"; };
-		3600247DEF721527846D6E97 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m"; sourceTree = "<group>"; };
-		366814AEF59CB4783023E14A /* HNKGooglePlacesServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesServer.h; path = Pod/Classes/HNKGooglePlacesServer.h; sourceTree = "<group>"; };
-		3704509641A36A2D62513BB8 /* HNKServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKServer.m; path = Pod/Classes/HNKServer.m; sourceTree = "<group>"; };
-		3841EF67FE7179A68A84E0AE /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3870F7AEEFC88A90F5A7843F /* KWBeWithinMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeWithinMatcher.m; path = Classes/Matchers/KWBeWithinMatcher.m; sourceTree = "<group>"; };
-		399D2ED2C85934046B6A4514 /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Classes/Core/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
-		3AA477C0733A7F62246D92AE /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
-		3C0B2189DE86ED20A3BAD445 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3CE228954A091185C7B66DD3 /* KWRespondToSelectorMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRespondToSelectorMatcher.m; path = Classes/Matchers/KWRespondToSelectorMatcher.m; sourceTree = "<group>"; };
-		40446B3518C6451DA590B417 /* KWStringContainsMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringContainsMatcher.m; path = Classes/Matchers/KWStringContainsMatcher.m; sourceTree = "<group>"; };
-		41B72D1C9AF5DE8F9674C438 /* KWMatching.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatching.h; path = Classes/Core/KWMatching.h; sourceTree = "<group>"; };
-		42590BEF82B08D7CAF608BA5 /* KWMatchVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatchVerifier.h; path = Classes/Verifiers/KWMatchVerifier.h; sourceTree = "<group>"; };
-		44F82ABA4EFB063310CAEB56 /* KWSuiteConfigurationBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSuiteConfigurationBase.h; path = Classes/Config/KWSuiteConfigurationBase.h; sourceTree = "<group>"; };
-		4628D4FB50A38945AD31B562 /* KWStringPrefixMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringPrefixMatcher.h; path = Classes/Matchers/KWStringPrefixMatcher.h; sourceTree = "<group>"; };
-		463DB134D54F5CA56C7B15B2 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		489AED0CA7A744874148C38F /* KWValue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWValue.m; path = Classes/Core/KWValue.m; sourceTree = "<group>"; };
-		4C071E90A2B093881945E007 /* KWAllTestsSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAllTestsSuite.m; path = Classes/Config/KWAllTestsSuite.m; sourceTree = "<group>"; };
-		4C79C8E6028D11DEA026CC7F /* KWMatcherFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatcherFactory.h; path = Classes/Core/KWMatcherFactory.h; sourceTree = "<group>"; };
-		4F0617556051049CE3782ED9 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig"; sourceTree = "<group>"; };
-		4FFD3A421ADEC11692C5FDA7 /* KWCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCallSite.h; path = Classes/Core/KWCallSite.h; sourceTree = "<group>"; };
-		50348AF571000FCEBD211904 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
-		503B283D7C48D72CB85B9B97 /* Kiwi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Kiwi.h; path = Classes/Core/Kiwi.h; sourceTree = "<group>"; };
-		5077A92DB8B6C8F61093497A /* NSObject+KiwiMockAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiMockAdditions.h"; path = "Classes/Mocking/NSObject+KiwiMockAdditions.h"; sourceTree = "<group>"; };
-		507903BDF700D2BCB157C2BE /* KWObjCUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWObjCUtilities.h; path = Classes/Core/KWObjCUtilities.h; sourceTree = "<group>"; };
-		514F9A798C30A399277D1D3B /* KWIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWIntercept.h; path = Classes/Stubbing/KWIntercept.h; sourceTree = "<group>"; };
-		524DD8795EB32D3367891014 /* KWFailure.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFailure.m; path = Classes/Core/KWFailure.m; sourceTree = "<group>"; };
-		528718D50628D958123419A4 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		541DDF273E86328788A60759 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch"; sourceTree = "<group>"; };
-		54599F64F8130FEA56ED3AAB /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
-		54952A3904808E7911D2CF44 /* KWExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExample.h; path = Classes/Core/KWExample.h; sourceTree = "<group>"; };
-		552F7E31625905B16A99DAE1 /* KWAsyncVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAsyncVerifier.h; path = Classes/Verifiers/KWAsyncVerifier.h; sourceTree = "<group>"; };
-		55899EC1EE25F7A4B0239DA3 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h"; sourceTree = "<group>"; };
-		55B98763EADB5D1DC0517869 /* KWBeKindOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeKindOfClassMatcher.m; path = Classes/Matchers/KWBeKindOfClassMatcher.m; sourceTree = "<group>"; };
-		5630292DF389227995A9073D /* KWMatchVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatchVerifier.m; path = Classes/Verifiers/KWMatchVerifier.m; sourceTree = "<group>"; };
-		566B17D79DDC937640420057 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+MTLManipulationAdditions.m"; path = "Mantle/NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		56C0C7987C8F8744D49ABBAD /* KWNilMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNilMatcher.m; path = Classes/Matchers/KWNilMatcher.m; sourceTree = "<group>"; };
-		56EC12DDEBCF3F4D479C186A /* KWStringUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringUtilities.m; path = Classes/Core/KWStringUtilities.m; sourceTree = "<group>"; };
-		5969993BFC9FB87120828703 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.h"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
-		5AC2E0AC895237BF26C5D502 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
-		5BBA2FA4976870BA76122515 /* KWNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNull.h; path = Classes/Core/KWNull.h; sourceTree = "<group>"; };
-		5C3725F98245305A17A32366 /* NSMethodSignature+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+KiwiAdditions.m"; path = "Classes/Core/NSMethodSignature+KiwiAdditions.m"; sourceTree = "<group>"; };
-		5D3D5832CB893C566BFABECE /* NSObject+KiwiVerifierAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiVerifierAdditions.m"; path = "Classes/Core/NSObject+KiwiVerifierAdditions.m"; sourceTree = "<group>"; };
-		5FDF1FF4209B5612BD8BD21A /* KWNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNull.m; path = Classes/Core/KWNull.m; sourceTree = "<group>"; };
-		6058D3062A8DF333A4783C55 /* KWBlock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlock.h; path = Classes/Core/KWBlock.h; sourceTree = "<group>"; };
-		622328EB72738488F729A0CC /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		629F12700A0778EB72709F29 /* KWNilMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNilMatcher.h; path = Classes/Matchers/KWNilMatcher.h; sourceTree = "<group>"; };
-		642BAD7D8C7EAB8F673C6135 /* KWMessageTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessageTracker.h; path = Classes/Core/KWMessageTracker.h; sourceTree = "<group>"; };
-		64F68705367E685E4E6156CD /* KWNotificationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNotificationMatcher.h; path = Classes/Matchers/KWNotificationMatcher.h; sourceTree = "<group>"; };
-		65901D87F22DFA6CDF20D05C /* KWContainMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContainMatcher.h; path = Classes/Matchers/KWContainMatcher.h; sourceTree = "<group>"; };
-		6629E9E33001114CA0233C9A /* KWInvocationCapturer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWInvocationCapturer.h; path = Classes/Core/KWInvocationCapturer.h; sourceTree = "<group>"; };
-		66C3005DEAE02A9C5F534AE5 /* MTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLValueTransformer.h; path = Mantle/MTLValueTransformer.h; sourceTree = "<group>"; };
-		671B91C3BA65219D4629CAD9 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		679C1158B8BAAD952684864D /* KWGenericMatchEvaluator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatchEvaluator.h; path = Classes/Matchers/KWGenericMatchEvaluator.h; sourceTree = "<group>"; };
-		67AFB1F55CB232E566BC3415 /* KWWorkarounds.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWWorkarounds.m; path = Classes/Core/KWWorkarounds.m; sourceTree = "<group>"; };
-		6A588CB962CE4B7C6A636689 /* KWEqualMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWEqualMatcher.m; path = Classes/Matchers/KWEqualMatcher.m; sourceTree = "<group>"; };
-		6A82A07158552AAD01985F4E /* KWChangeMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWChangeMatcher.m; path = Classes/Matchers/KWChangeMatcher.m; sourceTree = "<group>"; };
-		6B1CAE77C0A82214EE965418 /* KWBeBetweenMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeBetweenMatcher.h; path = Classes/Matchers/KWBeBetweenMatcher.h; sourceTree = "<group>"; };
-		6B211308C6CE641CA16A5234 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig"; sourceTree = "<group>"; };
-		6BCC1510FCC6D08CA800CE61 /* NSError+MTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+MTLModelException.h"; path = "Mantle/NSError+MTLModelException.h"; sourceTree = "<group>"; };
-		6BD42021E4EE0BC7921758F5 /* KWBeIdenticalToMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeIdenticalToMatcher.m; path = Classes/Matchers/KWBeIdenticalToMatcher.m; sourceTree = "<group>"; };
-		6E61E71CF66B835D22D0D59C /* KWAsyncVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAsyncVerifier.m; path = Classes/Verifiers/KWAsyncVerifier.m; sourceTree = "<group>"; };
-		6F2B5B228C98F5ED3B80A8A3 /* KWBlockRaiseMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlockRaiseMatcher.m; path = Classes/Matchers/KWBlockRaiseMatcher.m; sourceTree = "<group>"; };
-		6F41CED28A50A74D43C388E3 /* KWItNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWItNode.h; path = Classes/Nodes/KWItNode.h; sourceTree = "<group>"; };
-		715586B0584683CA46DCFE9A /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLConnectionOperation.h; path = AFNetworking/AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		7218F9CA3729532ED94FCDE1 /* KWExampleSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExampleSuiteBuilder.m; path = Classes/Core/KWExampleSuiteBuilder.m; sourceTree = "<group>"; };
-		7236E956CC48818885C33A91 /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig"; sourceTree = "<group>"; };
-		72FEF699AFF15DBBA4C41070 /* KWGenericMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatcher.h; path = Classes/Matchers/KWGenericMatcher.h; sourceTree = "<group>"; };
-		73664B7D1F47F9B033E743AF /* KWMatchers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatchers.m; path = Classes/Core/KWMatchers.m; sourceTree = "<group>"; };
-		73C9A96186E0625E38A62900 /* HNKGooglePlacesAutocompletePlaceTerm.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlaceTerm.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceTerm.m; sourceTree = "<group>"; };
-		75B305FBE817D0666537DCB0 /* CLPlacemark+HNKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CLPlacemark+HNKAdditions.h"; path = "Pod/Classes/CLPlacemark+HNKAdditions.h"; sourceTree = "<group>"; };
-		7651FB03E103BED64B9F65CA /* KWProbe.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWProbe.h; path = Classes/Core/KWProbe.h; sourceTree = "<group>"; };
-		76AF7A9FF3DA0179AA4D5D16 /* MTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLModel.m; path = Mantle/MTLModel.m; sourceTree = "<group>"; };
-		76B41C8DF968F6BFDD3EA1C1 /* KWInequalityMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWInequalityMatcher.h; path = Classes/Matchers/KWInequalityMatcher.h; sourceTree = "<group>"; };
-		7B241C5797BF73CAD17DEE03 /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = Mantle/extobjc/metamacros.h; sourceTree = "<group>"; };
-		7B95D45685BA004A661CF0AB /* MTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MTLModel+NSCoding.m"; path = "Mantle/MTLModel+NSCoding.m"; sourceTree = "<group>"; };
-		7C13729187073B91ADF5829F /* KWContextNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContextNode.m; path = Classes/Nodes/KWContextNode.m; sourceTree = "<group>"; };
-		7DCAEF6BA13B2C07DE1B3AB2 /* HNKGooglePlacesAutocompletePlace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlace.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlace.m; sourceTree = "<group>"; };
-		7E2B3034C8D6C680BD6B3B7B /* NSError+MTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+MTLModelException.m"; path = "Mantle/NSError+MTLModelException.m"; sourceTree = "<group>"; };
-		7EF1418F4699618D44A7C4A1 /* MTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLValueTransformer.m; path = Mantle/MTLValueTransformer.m; sourceTree = "<group>"; };
-		7F4CBD95A9689002F1ADFF5B /* KWConformToProtocolMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWConformToProtocolMatcher.h; path = Classes/Matchers/KWConformToProtocolMatcher.h; sourceTree = "<group>"; };
-		7F889D9AD0ABD06A4C589495 /* KWBeforeAllNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeforeAllNode.m; path = Classes/Nodes/KWBeforeAllNode.m; sourceTree = "<group>"; };
-		7F970DBF5D742A6176FE8F81 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
-		80EDA518B365CA1EE37E0A72 /* NSObject+KiwiStubAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiStubAdditions.m"; path = "Classes/Stubbing/NSObject+KiwiStubAdditions.m"; sourceTree = "<group>"; };
-		814A8B1366DEDD64C4EF4B02 /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = Mantle/extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		8318D271FFFC2D8C807BF761 /* KWMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatchers.h; path = Classes/Core/KWMatchers.h; sourceTree = "<group>"; };
-		833CF8BF2EE8EAF24EBEDB06 /* KWReceiveMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReceiveMatcher.h; path = Classes/Matchers/KWReceiveMatcher.h; sourceTree = "<group>"; };
-		83BF94C1175D1827277213AC /* KiwiBlockMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiBlockMacros.h; path = Classes/Core/KiwiBlockMacros.h; sourceTree = "<group>"; };
-		8482339B283BC309E62FC7FD /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = Mantle/extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
-		8618E224A86ACCDDC8D252F5 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
-		865802332036A75DEEED05AD /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig"; sourceTree = "<group>"; };
-		885D02036C980A5BD90474AE /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch"; sourceTree = "<group>"; };
-		89934EFF5ED5ACC58CA3990C /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLConnectionOperation.m; path = AFNetworking/AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		89F18F715860E6BF5FADCA94 /* MTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLModel.h; path = Mantle/MTLModel.h; sourceTree = "<group>"; };
-		8A6F11442FBAB1E548DC02BB /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
-		8B57D6EA1B7AAD8217DF422C /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig"; sourceTree = "<group>"; };
-		8BA0D05990AE655DBC165CA3 /* HNKGooglePlacesAutocompleteQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQuery.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQuery.m; sourceTree = "<group>"; };
-		8E02493ABB2EF8687A943186 /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = Mantle/extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		8E666D8CDFB2827BD290FD94 /* KWWorkarounds.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWWorkarounds.h; path = Classes/Core/KWWorkarounds.h; sourceTree = "<group>"; };
-		8F18FE0AE4A70EF9C80C4A15 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch"; sourceTree = "<group>"; };
-		907B0F75545CE02D065D0A0A /* KWNotificationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNotificationMatcher.m; path = Classes/Matchers/KWNotificationMatcher.m; sourceTree = "<group>"; };
-		90EEFEC5C1808D3309AEB101 /* KWStringPrefixMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringPrefixMatcher.m; path = Classes/Matchers/KWStringPrefixMatcher.m; sourceTree = "<group>"; };
-		91929C2D58C5A8416135B3A9 /* KWRespondToSelectorMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRespondToSelectorMatcher.h; path = Classes/Matchers/KWRespondToSelectorMatcher.h; sourceTree = "<group>"; };
-		91AABE1CED27C64C4286E907 /* KWIntercept.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWIntercept.m; path = Classes/Stubbing/KWIntercept.m; sourceTree = "<group>"; };
-		92F9AF1CA7B0B78E330BB74C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		9327B768AF5A3B77476DAAC6 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		93BB90D4A4462E6971C6588B /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
-		93BC3110E2CA77C352E2F55F /* NSObject+KiwiVerifierAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiVerifierAdditions.h"; path = "Classes/Core/NSObject+KiwiVerifierAdditions.h"; sourceTree = "<group>"; };
-		94D3D8BEE1C9B8758FFD82A1 /* KWGenericMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatcher.m; path = Classes/Matchers/KWGenericMatcher.m; sourceTree = "<group>"; };
-		957D4CCED793697634F0FE6C /* KWFailure.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFailure.h; path = Classes/Core/KWFailure.h; sourceTree = "<group>"; };
-		9687BE7EE32CA81984436E98 /* MTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLReflection.m; path = Mantle/MTLReflection.m; sourceTree = "<group>"; };
-		9693AF1049729EEBA3694554 /* UIAlertView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+AFNetworking.m"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.m"; sourceTree = "<group>"; };
-		97B0EA8F7C236D6E78477584 /* KWSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSpec.h; path = Classes/Core/KWSpec.h; sourceTree = "<group>"; };
-		99F9210D9297016A8B601EDC /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
-		9D25C95DF8C3FE2C2063D3D0 /* KWBeIdenticalToMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeIdenticalToMatcher.h; path = Classes/Matchers/KWBeIdenticalToMatcher.h; sourceTree = "<group>"; };
-		9D6541B6AEB83DE702D6D462 /* KWBeEmptyMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeEmptyMatcher.m; path = Classes/Matchers/KWBeEmptyMatcher.m; sourceTree = "<group>"; };
-		9D6CC4FE7A02C9544A0D972E /* KWStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStub.m; path = Classes/Stubbing/KWStub.m; sourceTree = "<group>"; };
-		9E32BAC80A45B250427A6DF6 /* KWExampleSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExampleSuite.m; path = Classes/Core/KWExampleSuite.m; sourceTree = "<group>"; };
-		9F758D3939FA3E07C9564ACF /* Mantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mantle.h; path = Mantle/Mantle.h; sourceTree = "<group>"; };
-		A02550277C4B216645124103 /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MTLComparisonAdditions.m"; path = "Mantle/NSObject+MTLComparisonAdditions.m"; sourceTree = "<group>"; };
-		A0BA6FF4233DAF5C8C29446F /* NSObject+KiwiMockAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiMockAdditions.m"; path = "Classes/Mocking/NSObject+KiwiMockAdditions.m"; sourceTree = "<group>"; };
-		A14FF3CA9DD7D496A75DBD57 /* KWStringContainsMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringContainsMatcher.h; path = Classes/Matchers/KWStringContainsMatcher.h; sourceTree = "<group>"; };
-		A2AD2FECEE02F33E7D99682B /* KWChangeMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWChangeMatcher.h; path = Classes/Matchers/KWChangeMatcher.h; sourceTree = "<group>"; };
-		A438BDF462D96AB0A0CD8393 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch"; sourceTree = "<group>"; };
-		A4E56118DD2D0E6A6082F715 /* NSMethodSignature+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+KiwiAdditions.h"; path = "Classes/Core/NSMethodSignature+KiwiAdditions.h"; sourceTree = "<group>"; };
-		A6033149BA898A01D7CCFB81 /* KWHaveValueMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWHaveValueMatcher.h; path = Classes/Matchers/KWHaveValueMatcher.h; sourceTree = "<group>"; };
-		A7641E8FDF1729CCE6B7467F /* KWFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFormatter.h; path = Classes/Core/KWFormatter.h; sourceTree = "<group>"; };
-		A7EF4F7BB348E92EED8C8280 /* KWCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWCallSite.m; path = Classes/Core/KWCallSite.m; sourceTree = "<group>"; };
-		A81DDAB84DA0B4468EA806F3 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
-		A844C1450535C965AF7F7B35 /* NSObject+KiwiSpyAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiSpyAdditions.m"; path = "Classes/Core/NSObject+KiwiSpyAdditions.m"; sourceTree = "<group>"; };
-		A9E85D413300BA1CABFE332F /* KWMatcherFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatcherFactory.m; path = Classes/Core/KWMatcherFactory.m; sourceTree = "<group>"; };
-		AA58AC1AA206F2F88B8BA2B2 /* NSValue+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+KiwiAdditions.h"; path = "Classes/Core/NSValue+KiwiAdditions.h"; sourceTree = "<group>"; };
-		AB509B781FD98D50B689B528 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		AB9F10D2B85AFB59BEDAFB9B /* KWBlockNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlockNode.m; path = Classes/Nodes/KWBlockNode.m; sourceTree = "<group>"; };
-		ACF773841CF5AE9A43C40A11 /* KWLetNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWLetNode.m; path = Classes/Nodes/KWLetNode.m; sourceTree = "<group>"; };
-		AD933846CC281937034B592A /* KWGenericMatchingAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatchingAdditions.m; path = Classes/Matchers/KWGenericMatchingAdditions.m; sourceTree = "<group>"; };
-		AF2BF1DE1D58442CD08EC0C0 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		AFDA29167395549A876336AB /* HNKGooglePlacesAutocompleteQueryResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQueryResponse.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryResponse.m; sourceTree = "<group>"; };
-		B1785E19D8C6C1D8A8DD4C10 /* KWExistVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExistVerifier.h; path = Classes/Verifiers/KWExistVerifier.h; sourceTree = "<group>"; };
-		B23F91B1034773CC84FD498A /* KWBlockNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlockNode.h; path = Classes/Nodes/KWBlockNode.h; sourceTree = "<group>"; };
-		B28DE78EEE80838E012C7B0F /* HNKGooglePlacesAutocompleteModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteModel.h; path = Pod/Classes/HNKGooglePlacesAutocompleteModel.h; sourceTree = "<group>"; };
-		B36EE767CA131A4A4CEB7AFB /* NSProxy+KiwiVerifierAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSProxy+KiwiVerifierAdditions.m"; path = "Classes/Core/NSProxy+KiwiVerifierAdditions.m"; sourceTree = "<group>"; };
-		B379A30ABBAE39E5A9E3586F /* NSInvocation+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+KiwiAdditions.m"; path = "Classes/Core/NSInvocation+KiwiAdditions.m"; sourceTree = "<group>"; };
-		B4787CCF45906E24C3527722 /* KWBeZeroMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeZeroMatcher.m; path = Classes/Matchers/KWBeZeroMatcher.m; sourceTree = "<group>"; };
-		B52048C116FAE60E1A66EE03 /* NSValue+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+KiwiAdditions.m"; path = "Classes/Core/NSValue+KiwiAdditions.m"; sourceTree = "<group>"; };
-		B523B0A4E0B5598F0B83CA4A /* KWGenericMatchingAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatchingAdditions.h; path = Classes/Matchers/KWGenericMatchingAdditions.h; sourceTree = "<group>"; };
-		B526551D60FA1636B3A7BFE1 /* MTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLManagedObjectAdapter.h; path = Mantle/MTLManagedObjectAdapter.h; sourceTree = "<group>"; };
-		B77F414322EC57E03D000540 /* KWBeSubclassOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeSubclassOfClassMatcher.h; path = Classes/Matchers/KWBeSubclassOfClassMatcher.h; sourceTree = "<group>"; };
-		B77F89E73CE58FC4DD469316 /* MTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLJSONAdapter.m; path = Mantle/MTLJSONAdapter.m; sourceTree = "<group>"; };
-		B7CD89BD5058A4CB855232BF /* NSInvocation+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+KiwiAdditions.h"; path = "Classes/Core/NSInvocation+KiwiAdditions.h"; sourceTree = "<group>"; };
-		B823608C11E6630A0D1DD9E6 /* KWBeEmptyMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeEmptyMatcher.h; path = Classes/Matchers/KWBeEmptyMatcher.h; sourceTree = "<group>"; };
-		BB22393EDB8A17E11272A9D4 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-dummy.m"; sourceTree = "<group>"; };
-		BB7DCF24D68837822F951E4E /* KWBeKindOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeKindOfClassMatcher.h; path = Classes/Matchers/KWBeKindOfClassMatcher.h; sourceTree = "<group>"; };
-		BBF123EFFF84231EBE704A71 /* HNKGooglePlacesAutocompletePlace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlace.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlace.h; sourceTree = "<group>"; };
-		BD940068FC02B7E9843F1D43 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
-		BE959059924AF347BB6E2C87 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
-		BF2F35DB5FD04A1F92CE3703 /* KWMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatcher.m; path = Classes/Core/KWMatcher.m; sourceTree = "<group>"; };
-		C01DE0D96B4C5EA28A859B57 /* KWRegularExpressionPatternMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRegularExpressionPatternMatcher.m; path = Classes/Matchers/KWRegularExpressionPatternMatcher.m; sourceTree = "<group>"; };
-		C0964C150FEF43E7E4ADCF86 /* KWAfterAllNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAfterAllNode.m; path = Classes/Nodes/KWAfterAllNode.m; sourceTree = "<group>"; };
-		C0C93AF33F7414590A8E1744 /* KWContainStringMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContainStringMatcher.h; path = Classes/Matchers/KWContainStringMatcher.h; sourceTree = "<group>"; };
-		C108D3F5C43FA2B278F6D600 /* Pods-HNKGooglePlacesAutocomplete-Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-HNKGooglePlacesAutocomplete-Example-resources.sh"; sourceTree = "<group>"; };
-		C1C32F33088BD57D15678ED2 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		C2D031CC4916ED55FC3A0AFD /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m"; sourceTree = "<group>"; };
-		C2FC490D291EB30EA05E1396 /* KWAfterEachNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAfterEachNode.h; path = Classes/Nodes/KWAfterEachNode.h; sourceTree = "<group>"; };
-		C31758A781FF3D2462845A17 /* KWBeZeroMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeZeroMatcher.h; path = Classes/Matchers/KWBeZeroMatcher.h; sourceTree = "<group>"; };
-		C3F1C002D7BAFA5AC5DF4759 /* KWMessageSpying.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessageSpying.h; path = Classes/Core/KWMessageSpying.h; sourceTree = "<group>"; };
-		C630E66B948CBA4EB25A0040 /* MTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLManagedObjectAdapter.m; path = Mantle/MTLManagedObjectAdapter.m; sourceTree = "<group>"; };
-		C7B74DB16DEA2D85A82F5164 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		C849A5EEE47D2960A2EED7ED /* HNKGooglePlacesAutocompleteQueryConfig.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQueryConfig.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryConfig.h; sourceTree = "<group>"; };
-		C8800830D40E0DB93DB55C6F /* KWStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStub.h; path = Classes/Stubbing/KWStub.h; sourceTree = "<group>"; };
-		C981976B39400360F0B01300 /* KWLet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWLet.h; path = Classes/Core/KWLet.h; sourceTree = "<group>"; };
-		CA4899804A758DF0ADCB4951 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
-		CABE66DCCB1E4FF723B70935 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch"; sourceTree = "<group>"; };
-		CB3557CDA61806D6B2598719 /* MTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLReflection.h; path = Mantle/MTLReflection.h; sourceTree = "<group>"; };
-		CB5302C1896503B58AA0DD46 /* MTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MTLModel+NSCoding.h"; path = "Mantle/MTLModel+NSCoding.h"; sourceTree = "<group>"; };
-		CC717C8EF29AA29ECFFBDCFB /* NSObject+KiwiSpyAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiSpyAdditions.h"; path = "Classes/Core/NSObject+KiwiSpyAdditions.h"; sourceTree = "<group>"; };
-		CC896C8AD4820DB3566C91F6 /* KWMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMock.h; path = Classes/Mocking/KWMock.h; sourceTree = "<group>"; };
-		CCA546F8F3DE397A2CEC7F37 /* KWEqualMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWEqualMatcher.h; path = Classes/Matchers/KWEqualMatcher.h; sourceTree = "<group>"; };
-		CD00EFE92810301CEB7BB9B2 /* NSValueTransformer+MTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLInversionAdditions.m"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.m"; sourceTree = "<group>"; };
-		CD05CAFA709E112E89C22030 /* HNKGooglePlacesAutocompleteQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQuery.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQuery.h; sourceTree = "<group>"; };
-		CD3EF45202C88562C1A46E53 /* KWAny.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAny.h; path = Classes/Core/KWAny.h; sourceTree = "<group>"; };
-		CD57BDC361AF3A229800C9E8 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CE9C128C1678730ABEC08982 /* KWDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWDeviceInfo.h; path = Classes/Core/KWDeviceInfo.h; sourceTree = "<group>"; };
-		CF12D98189040C5F6F39B5B8 /* KWContextNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContextNode.h; path = Classes/Nodes/KWContextNode.h; sourceTree = "<group>"; };
-		D0DFA811837E110097548562 /* KWAfterAllNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAfterAllNode.h; path = Classes/Nodes/KWAfterAllNode.h; sourceTree = "<group>"; };
-		D1C146F23388445B2E1CAA58 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig"; sourceTree = "<group>"; };
-		D42F0DAED7DDCA342AB76E33 /* NSNumber+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNumber+KiwiAdditions.m"; path = "Classes/Core/NSNumber+KiwiAdditions.m"; sourceTree = "<group>"; };
-		D45CD445CA24EC3B1F961BE9 /* KWMessagePattern.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessagePattern.h; path = Classes/Core/KWMessagePattern.h; sourceTree = "<group>"; };
-		D546BE0F1FB90DF22AC1C82E /* KWBeMemberOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeMemberOfClassMatcher.m; path = Classes/Matchers/KWBeMemberOfClassMatcher.m; sourceTree = "<group>"; };
-		D54940755402EBF0AB576D14 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperation.m; path = AFNetworking/AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		D5CA701E1BCFC07E3492D623 /* KiwiMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiMacros.h; path = Classes/Core/KiwiMacros.h; sourceTree = "<group>"; };
-		D73B3869B812FE56D84D1B6B /* NSObject+KiwiStubAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiStubAdditions.h"; path = "Classes/Stubbing/NSObject+KiwiStubAdditions.h"; sourceTree = "<group>"; };
-		D75B074A690D1E34D1DD609E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig"; sourceTree = "<group>"; };
-		D79F1581656F9D57C860E43C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		D8AAF812744AA4E992973552 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		DA8DFE431B39C713FEA278AF /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperation.h; path = AFNetworking/AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		DB0A3962E173AFB8ABF85897 /* HNKGooglePlacesAutocompletePlaceSubstring.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlaceSubstring.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceSubstring.m; sourceTree = "<group>"; };
-		DC7CAC1595068A552CFA9C00 /* KWObjCUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWObjCUtilities.m; path = Classes/Core/KWObjCUtilities.m; sourceTree = "<group>"; };
-		DCDCF0CF41B32F57A41130EE /* KWFutureObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFutureObject.h; path = Classes/Core/KWFutureObject.h; sourceTree = "<group>"; };
-		DD0C618A00A60E95D57CB846 /* HNKGooglePlacesAutocompletePlaceSubstring.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlaceSubstring.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceSubstring.h; sourceTree = "<group>"; };
-		DDE49CE00D1BF5DB70D6736B /* KWExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExample.m; path = Classes/Core/KWExample.m; sourceTree = "<group>"; };
-		DF6DA094E2C869C6044F563B /* KWMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatcher.h; path = Classes/Core/KWMatcher.h; sourceTree = "<group>"; };
-		E14D398200422A4E56663811 /* HNKGooglePlacesAutocompleteModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteModel.m; path = Pod/Classes/HNKGooglePlacesAutocompleteModel.m; sourceTree = "<group>"; };
-		E1847C045372449807F42421 /* KWExampleDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleDelegate.h; path = Classes/Core/KWExampleDelegate.h; sourceTree = "<group>"; };
-		E2F060FF644B5BAFB3BB1E19 /* KWFutureObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFutureObject.m; path = Classes/Core/KWFutureObject.m; sourceTree = "<group>"; };
-		E3D4AC8A607F5E0322DF09FB /* KWBeSubclassOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeSubclassOfClassMatcher.m; path = Classes/Matchers/KWBeSubclassOfClassMatcher.m; sourceTree = "<group>"; };
-		E4517F0FEB205454DC86A3A0 /* KWSymbolicator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSymbolicator.h; path = Classes/Core/KWSymbolicator.h; sourceTree = "<group>"; };
-		E55B402FF75765CBC664F624 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig"; sourceTree = "<group>"; };
-		E62C7358155AD7ABC39F5660 /* HNKGooglePlacesAutocomplete.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocomplete.h; path = Pod/Classes/HNKGooglePlacesAutocomplete.h; sourceTree = "<group>"; };
-		E6BCEDBB89EC33D04924341C /* KWGenericMatchEvaluator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatchEvaluator.m; path = Classes/Matchers/KWGenericMatchEvaluator.m; sourceTree = "<group>"; };
-		E7704007FEA95FD1AD5C3A94 /* KWHaveValueMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWHaveValueMatcher.m; path = Classes/Matchers/KWHaveValueMatcher.m; sourceTree = "<group>"; };
-		E7AACA8EF1FADE1E604140BF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig"; sourceTree = "<group>"; };
-		E7E34CCAACC7F15837B2712D /* NSDictionary+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLManipulationAdditions.m"; path = "Mantle/NSDictionary+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
-		E9DFA3A7B2F0FB5152135BBB /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig"; sourceTree = "<group>"; };
-		EA60E0FEBD516D4841B15308 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig"; sourceTree = "<group>"; };
-		EA633D4055285F175E4A0D17 /* KWExampleSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleSuite.h; path = Classes/Core/KWExampleSuite.h; sourceTree = "<group>"; };
-		EAC6036D5810A768A474A930 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		EBF98612B0897213DD578979 /* HNKGooglePlacesAutocompletePlaceTerm.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlaceTerm.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceTerm.h; sourceTree = "<group>"; };
-		EC23F87A1E1972BE10A42D7C /* KWReceiveMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWReceiveMatcher.m; path = Classes/Matchers/KWReceiveMatcher.m; sourceTree = "<group>"; };
-		EC351FCC3271E6CE21F92B3C /* KWExampleSuiteBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleSuiteBuilder.h; path = Classes/Core/KWExampleSuiteBuilder.h; sourceTree = "<group>"; };
-		EE0DFB53F0397C1DF256A780 /* KWExampleNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleNode.h; path = Classes/Nodes/KWExampleNode.h; sourceTree = "<group>"; };
-		EE7A9058CDD102A5B6C74A36 /* libPods-HNKGooglePlacesAutocomplete-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EF290D9FE55F90B190D34E3B /* KWContainMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContainMatcher.m; path = Classes/Matchers/KWContainMatcher.m; sourceTree = "<group>"; };
-		EFA4FD58A097B9F2E875C31A /* KiwiConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiConfiguration.h; path = Classes/Core/KiwiConfiguration.h; sourceTree = "<group>"; };
-		F0BC7E121DBE7C0A31863772 /* KWExistVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExistVerifier.m; path = Classes/Verifiers/KWExistVerifier.m; sourceTree = "<group>"; };
-		F0CA13ADB263ACC181A08177 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh"; sourceTree = "<group>"; };
-		F17E9250A54A1DEB562E8A70 /* KWBlockRaiseMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlockRaiseMatcher.h; path = Classes/Matchers/KWBlockRaiseMatcher.h; sourceTree = "<group>"; };
-		F1D69FAB40D9AFB30395EC16 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		F2D694F13E04E93E9CB358D8 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		F2FADAACB261E7B8C528B2A3 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
-		F315C29ED0107A0C2DA052AA /* KWSuiteConfigurationBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSuiteConfigurationBase.m; path = Classes/Config/KWSuiteConfigurationBase.m; sourceTree = "<group>"; };
-		F42B202288760C1ED0022F88 /* KWHaveMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWHaveMatcher.m; path = Classes/Matchers/KWHaveMatcher.m; sourceTree = "<group>"; };
-		F520F38C42A187E464C87AEB /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		F5AE4FB643934531473F9160 /* HNKGooglePlacesAutocompleteQueryConfig.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQueryConfig.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryConfig.m; sourceTree = "<group>"; };
-		F64E9C695ED031D185C06578 /* KWRegisterMatchersNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRegisterMatchersNode.m; path = Classes/Nodes/KWRegisterMatchersNode.m; sourceTree = "<group>"; };
-		F7E0417F2C086086102C458C /* KWProbePoller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWProbePoller.h; path = Classes/Core/KWProbePoller.h; sourceTree = "<group>"; };
-		F7E71889CE8FC74C6051CC1F /* KWBeMemberOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeMemberOfClassMatcher.h; path = Classes/Matchers/KWBeMemberOfClassMatcher.h; sourceTree = "<group>"; };
-		F831B34D33FF8BD23A15AFDB /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = Mantle/extobjc/EXTScope.h; sourceTree = "<group>"; };
-		F94E5915D04125DB58B0B4D3 /* KWInequalityMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWInequalityMatcher.m; path = Classes/Matchers/KWInequalityMatcher.m; sourceTree = "<group>"; };
-		FBDDD2C0610ABC8BB87E7795 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		FC2CB85DD5635F9E50FC17C7 /* KWValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWValue.h; path = Classes/Core/KWValue.h; sourceTree = "<group>"; };
-		FC97DD9187B314F2024D7310 /* KWCountType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCountType.h; path = Classes/Core/KWCountType.h; sourceTree = "<group>"; };
-		FD893CE9B36A0CB2D5BB0705 /* KWPendingNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWPendingNode.m; path = Classes/Nodes/KWPendingNode.m; sourceTree = "<group>"; };
-		FE5273F18E60934B8B3F7DA0 /* KWBeWithinMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeWithinMatcher.h; path = Classes/Matchers/KWBeWithinMatcher.h; sourceTree = "<group>"; };
-		FEE751FE63E66BFA79BC9BF6 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		00B21D11C3694710193BFFF4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		00C1E48997104B8A0CE661DE /* KWMatchVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatchVerifier.m; path = Classes/Verifiers/KWMatchVerifier.m; sourceTree = "<group>"; };
+		00E6BEBF7C1394A81B96155B /* KWExampleSuiteBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleSuiteBuilder.h; path = Classes/Core/KWExampleSuiteBuilder.h; sourceTree = "<group>"; };
+		010243B947001D659539D13C /* HNKGooglePlacesAutocompleteQuery.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQuery.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQuery.h; sourceTree = "<group>"; };
+		010EF7A76D170571A78B65F8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.m"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.m"; sourceTree = "<group>"; };
+		0362F1E849DC4875CFF89286 /* KWContextNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContextNode.m; path = Classes/Nodes/KWContextNode.m; sourceTree = "<group>"; };
+		055E7CEDD00DFBBEB15AF336 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig"; sourceTree = "<group>"; };
+		06641A7F1991A534516CFC29 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m"; sourceTree = "<group>"; };
+		07452410253F30793CC25F31 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m"; sourceTree = "<group>"; };
+		07BEBE406BA569F669FF4460 /* KWMatcherFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatcherFactory.h; path = Classes/Core/KWMatcherFactory.h; sourceTree = "<group>"; };
+		0820F16F80DF639DAEF75CBC /* AFHTTPRequestOperationManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperationManager.m; path = AFNetworking/AFHTTPRequestOperationManager.m; sourceTree = "<group>"; };
+		082B0A7B4F1A3D04E393E7A0 /* KWFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFormatter.h; path = Classes/Core/KWFormatter.h; sourceTree = "<group>"; };
+		0849B79997BC56E6E1F320CA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		08824E825A6719898C23256D /* KWMessageTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessageTracker.h; path = Classes/Core/KWMessageTracker.h; sourceTree = "<group>"; };
+		08A19783740EEB46F94713DB /* KWStringContainsMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringContainsMatcher.m; path = Classes/Matchers/KWStringContainsMatcher.m; sourceTree = "<group>"; };
+		09F2B9ACCA75884893CEB73C /* KWBeZeroMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeZeroMatcher.h; path = Classes/Matchers/KWBeZeroMatcher.h; sourceTree = "<group>"; };
+		0A685B442042426996D1B790 /* KWValue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWValue.m; path = Classes/Core/KWValue.m; sourceTree = "<group>"; };
+		0A7A873270F44E276387B15A /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AB4D15FAD0279C2A6C3C934 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		0ACAE2CA1D731030F14985F4 /* MTLManagedObjectAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLManagedObjectAdapter.h; path = Mantle/MTLManagedObjectAdapter.h; sourceTree = "<group>"; };
+		0AD2DCFCB40D91C3836479BE /* KWAfterEachNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAfterEachNode.h; path = Classes/Nodes/KWAfterEachNode.h; sourceTree = "<group>"; };
+		0BEB31C64F8A1853B465370C /* KWBlock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlock.h; path = Classes/Core/KWBlock.h; sourceTree = "<group>"; };
+		0C432A4558C1D7D51BE399B3 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch"; sourceTree = "<group>"; };
+		0DE08483D913F364A4B88314 /* KWBlockRaiseMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlockRaiseMatcher.m; path = Classes/Matchers/KWBlockRaiseMatcher.m; sourceTree = "<group>"; };
+		0E6CE5E5C0DF10ABD47EE09F /* KWStringContainsMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringContainsMatcher.h; path = Classes/Matchers/KWStringContainsMatcher.h; sourceTree = "<group>"; };
+		1052FAC22AA67AF2EC36D7E2 /* KWBeWithinMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeWithinMatcher.h; path = Classes/Matchers/KWBeWithinMatcher.h; sourceTree = "<group>"; };
+		105D446E4751C4E31439EE7A /* KWEqualMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWEqualMatcher.h; path = Classes/Matchers/KWEqualMatcher.h; sourceTree = "<group>"; };
+		10D0B97615587ECBE1931B49 /* KWBlockRaiseMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlockRaiseMatcher.h; path = Classes/Matchers/KWBlockRaiseMatcher.h; sourceTree = "<group>"; };
+		10EDB71B91B02F2A1BD684D0 /* KWStringPrefixMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringPrefixMatcher.h; path = Classes/Matchers/KWStringPrefixMatcher.h; sourceTree = "<group>"; };
+		12268B1FAAF4DD67D8F90ED3 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		1600E36AE9638A28927580CA /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = Mantle/extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		1AE8ECEF2A2E1B6EBCF26FBA /* KWCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCallSite.h; path = Classes/Core/KWCallSite.h; sourceTree = "<group>"; };
+		1B8FDEEB3D678AAEFBB7B5EE /* HNKGooglePlacesAutocomplete.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocomplete.h; path = Pod/Classes/HNKGooglePlacesAutocomplete.h; sourceTree = "<group>"; };
+		1D26DAE34B95815CB3975075 /* NSError+MTLModelException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError+MTLModelException.m"; path = "Mantle/NSError+MTLModelException.m"; sourceTree = "<group>"; };
+		1EB0717FF7CCD9B875B271BC /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		20DAC95D224EAFE70DB75ADC /* KWHaveValueMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWHaveValueMatcher.m; path = Classes/Matchers/KWHaveValueMatcher.m; sourceTree = "<group>"; };
+		2217CC03D3430D9508A8B50E /* MTLReflection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLReflection.h; path = Mantle/MTLReflection.h; sourceTree = "<group>"; };
+		227F1CA02855AA44E3F2CA53 /* HNKGooglePlacesAutocompletePlaceTerm.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlaceTerm.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceTerm.h; sourceTree = "<group>"; };
+		228B9B1BEBC410181B0E354D /* KWFutureObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFutureObject.m; path = Classes/Core/KWFutureObject.m; sourceTree = "<group>"; };
+		22E78055A602629E8E4B3C2F /* HNKServerFacade.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKServerFacade.h; path = Pod/Classes/HNKServerFacade.h; sourceTree = "<group>"; };
+		233FEC86EFB6F219E93105A7 /* HNKGooglePlacesAutocompletePlace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlace.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlace.h; sourceTree = "<group>"; };
+		23B097853E62D4101D8829C5 /* KWLetNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWLetNode.m; path = Classes/Nodes/KWLetNode.m; sourceTree = "<group>"; };
+		25491BAADBFD661DD7CBA8CF /* KWBeBetweenMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeBetweenMatcher.m; path = Classes/Matchers/KWBeBetweenMatcher.m; sourceTree = "<group>"; };
+		255B6246724D372E0C784913 /* KWRegisterMatchersNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRegisterMatchersNode.h; path = Classes/Nodes/KWRegisterMatchersNode.h; sourceTree = "<group>"; };
+		2581A7786B7C24654918E1CD /* NSMethodSignature+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+KiwiAdditions.m"; path = "Classes/Core/NSMethodSignature+KiwiAdditions.m"; sourceTree = "<group>"; };
+		25926D5CE0A7337B84AAD14B /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		26616A12D74485DD7F35AFC3 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-dummy.m"; sourceTree = "<group>"; };
+		281BA20036AA57DBA9A1AF9C /* KWMessageSpying.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessageSpying.h; path = Classes/Core/KWMessageSpying.h; sourceTree = "<group>"; };
+		292F2E33DDFAE0DC4004FC29 /* KWChangeMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWChangeMatcher.h; path = Classes/Matchers/KWChangeMatcher.h; sourceTree = "<group>"; };
+		29E19316023814B3DF17CC6C /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		2B033E63CE53E620F14B1722 /* KWCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWCallSite.m; path = Classes/Core/KWCallSite.m; sourceTree = "<group>"; };
+		2B0E839C7378C0738E9E3BC6 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m"; sourceTree = "<group>"; };
+		2B88B0754D37D90A3EB09B37 /* NSObject+MTLComparisonAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MTLComparisonAdditions.m"; path = "Mantle/NSObject+MTLComparisonAdditions.m"; sourceTree = "<group>"; };
+		2DEF0B9E43511051CFDA9351 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig"; sourceTree = "<group>"; };
+		2EB13C6A3EC95EC04FB86C0F /* NSInvocation+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+KiwiAdditions.h"; path = "Classes/Core/NSInvocation+KiwiAdditions.h"; sourceTree = "<group>"; };
+		2EFB6B59B47D52A12A40191A /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		2F49B6A6512CEDDBB5F3B139 /* KWObjCUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWObjCUtilities.h; path = Classes/Core/KWObjCUtilities.h; sourceTree = "<group>"; };
+		30504226DD5EE7261A3ACE8E /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h"; sourceTree = "<group>"; };
+		30D6991BB531EED14CE12034 /* KWProbePoller.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWProbePoller.m; path = Classes/Core/KWProbePoller.m; sourceTree = "<group>"; };
+		31582A72A256A5F5579C40BC /* KWMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatcher.m; path = Classes/Core/KWMatcher.m; sourceTree = "<group>"; };
+		3212FD172EC8CC8484E012F2 /* HNKGooglePlacesAutocompleteModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteModel.m; path = Pod/Classes/HNKGooglePlacesAutocompleteModel.m; sourceTree = "<group>"; };
+		355DEDFA5869A2C4E5BE70E2 /* KWEqualMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWEqualMatcher.m; path = Classes/Matchers/KWEqualMatcher.m; sourceTree = "<group>"; };
+		35ECB7026521B5F706F02C8F /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig"; sourceTree = "<group>"; };
+		37318A03ABD30BF24418AC75 /* KWNilMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNilMatcher.m; path = Classes/Matchers/KWNilMatcher.m; sourceTree = "<group>"; };
+		37E14587827A8C3CC6C35538 /* KWChangeMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWChangeMatcher.m; path = Classes/Matchers/KWChangeMatcher.m; sourceTree = "<group>"; };
+		39320D3F8464D4AD985D1A6A /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A5E9DEB1501BABA40C65EA6 /* KWCountType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCountType.h; path = Classes/Core/KWCountType.h; sourceTree = "<group>"; };
+		3A7D0076E69942EF861C830B /* Kiwi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Kiwi.h; path = Classes/Core/Kiwi.h; sourceTree = "<group>"; };
+		3AA082184C08EE4AC2B11DB1 /* NSNumber+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNumber+KiwiAdditions.h"; path = "Classes/Core/NSNumber+KiwiAdditions.h"; sourceTree = "<group>"; };
+		3B56A5DBD79C00A37FBF1674 /* KWGenericMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatcher.m; path = Classes/Matchers/KWGenericMatcher.m; sourceTree = "<group>"; };
+		3CC29ACC246DA6F7E1F67EFC /* UIAlertView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+AFNetworking.h"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.h"; sourceTree = "<group>"; };
+		3CE46019B390E97F8DF7EA63 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
+		3EDBB25B482BC397819DA2B6 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		3FB7CB2E54BF7556D6507620 /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = Mantle/extobjc/EXTScope.h; sourceTree = "<group>"; };
+		3FE37FBCA3F0F2B03324323A /* KWHaveMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWHaveMatcher.m; path = Classes/Matchers/KWHaveMatcher.m; sourceTree = "<group>"; };
+		40150474A41CDBE269D53516 /* KWProbe.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWProbe.h; path = Classes/Core/KWProbe.h; sourceTree = "<group>"; };
+		40793574779A3C35386709EB /* HNKGooglePlacesServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesServer.m; path = Pod/Classes/HNKGooglePlacesServer.m; sourceTree = "<group>"; };
+		40A66751315DFD2CF46319DB /* KWLetNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWLetNode.h; path = Classes/Nodes/KWLetNode.h; sourceTree = "<group>"; };
+		40EAB20C2A9D2282510B5C57 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		4107BE41A34681EEC76F2005 /* KWMatchers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatchers.m; path = Classes/Core/KWMatchers.m; sourceTree = "<group>"; };
+		412A1CE6E03657223EC2364C /* NSObject+KiwiStubAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiStubAdditions.h"; path = "Classes/Stubbing/NSObject+KiwiStubAdditions.h"; sourceTree = "<group>"; };
+		4137EDD51DDC99D208F718F9 /* KWMatching.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatching.h; path = Classes/Core/KWMatching.h; sourceTree = "<group>"; };
+		4181F501C93565E53918C60E /* KWReceiveMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReceiveMatcher.h; path = Classes/Matchers/KWReceiveMatcher.h; sourceTree = "<group>"; };
+		42E473123FE91DED9D3D1D80 /* KWMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatcher.h; path = Classes/Core/KWMatcher.h; sourceTree = "<group>"; };
+		42F3358E6EDDD99BDA97257D /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
+		44218131D89E3B1FC9D5A09B /* KWDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWDeviceInfo.h; path = Classes/Core/KWDeviceInfo.h; sourceTree = "<group>"; };
+		4422846B47EAB643E3520E1C /* KWNotificationMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNotificationMatcher.h; path = Classes/Matchers/KWNotificationMatcher.h; sourceTree = "<group>"; };
+		45CF2C549C5C7D4EA674CC93 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig"; sourceTree = "<group>"; };
+		47DCF8E0D2E39A55AFDF9FF8 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch"; sourceTree = "<group>"; };
+		4841DA8221B6D68DA8732C2C /* NSNumber+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNumber+KiwiAdditions.m"; path = "Classes/Core/NSNumber+KiwiAdditions.m"; sourceTree = "<group>"; };
+		4934A9E5653138F02A72E15F /* KWValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWValue.h; path = Classes/Core/KWValue.h; sourceTree = "<group>"; };
+		49EF17E0F1C2B8E07C24A8AE /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		4C9BEC7E78E2C7E6ED7C8B56 /* KWRegisterMatchersNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRegisterMatchersNode.m; path = Classes/Nodes/KWRegisterMatchersNode.m; sourceTree = "<group>"; };
+		4CD929DAC6F4C02089D2660D /* NSInvocation+OCMAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+OCMAdditions.m"; path = "Classes/Core/NSInvocation+OCMAdditions.m"; sourceTree = "<group>"; };
+		4FF7DD1383EB27EE2167A32F /* KWSuiteConfigurationBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSuiteConfigurationBase.m; path = Classes/Config/KWSuiteConfigurationBase.m; sourceTree = "<group>"; };
+		500A16F2ABC6DC83680E6D2B /* KWGenericMatchEvaluator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatchEvaluator.m; path = Classes/Matchers/KWGenericMatchEvaluator.m; sourceTree = "<group>"; };
+		527E19CCCBDEAEB120D2D375 /* NSArray+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+MTLManipulationAdditions.m"; path = "Mantle/NSArray+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		52ECC1CB169F733F4FFD21C4 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m"; sourceTree = "<group>"; };
+		549CC6A6E90DC4DB5E187E3F /* KWConformToProtocolMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWConformToProtocolMatcher.h; path = Classes/Matchers/KWConformToProtocolMatcher.h; sourceTree = "<group>"; };
+		552DBDE7DCDDC365C46EE3CC /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
+		5547E8946415BCFF2687C3FB /* KiwiBlockMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiBlockMacros.h; path = Classes/Core/KiwiBlockMacros.h; sourceTree = "<group>"; };
+		556248D7BF1D82E692C9FD09 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLPredefinedTransformerAdditions.h"; path = "Mantle/NSValueTransformer+MTLPredefinedTransformerAdditions.h"; sourceTree = "<group>"; };
+		55F2D768E9521D4DAD42E11A /* KWExpectationType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExpectationType.h; path = Classes/Core/KWExpectationType.h; sourceTree = "<group>"; };
+		57953201D1E6F7E1007483B5 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
+		59E45A735D023A120B193A4D /* KWFutureObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFutureObject.h; path = Classes/Core/KWFutureObject.h; sourceTree = "<group>"; };
+		5A04A85A4AF45E09211D05F7 /* HNKGooglePlacesAutocompleteQueryResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQueryResponse.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryResponse.m; sourceTree = "<group>"; };
+		5A72E3B0CDBD39D96F700573 /* KWItNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWItNode.m; path = Classes/Nodes/KWItNode.m; sourceTree = "<group>"; };
+		5AF59C17EC4BA068CDDC0EE6 /* HNKGooglePlacesServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesServer.h; path = Pod/Classes/HNKGooglePlacesServer.h; sourceTree = "<group>"; };
+		5BBD3815CF09824050FAD0F3 /* HNKGooglePlacesAutocompleteModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteModel.h; path = Pod/Classes/HNKGooglePlacesAutocompleteModel.h; sourceTree = "<group>"; };
+		5C09740098CB0ED04CF0EF8D /* KWBeMemberOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeMemberOfClassMatcher.m; path = Classes/Matchers/KWBeMemberOfClassMatcher.m; sourceTree = "<group>"; };
+		5DDBAFD254E5AD1C22F4B3B5 /* MTLModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLModel.m; path = Mantle/MTLModel.m; sourceTree = "<group>"; };
+		5DF178E8FF4ACE4BCE67088D /* KWSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSpec.h; path = Classes/Core/KWSpec.h; sourceTree = "<group>"; };
+		5E07464270DE11E89C54B14A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig"; sourceTree = "<group>"; };
+		5F78D1C482590761967E5705 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FAAAC985E41A4C51982669F /* UIAlertView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+AFNetworking.m"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.m"; sourceTree = "<group>"; };
+		5FC592DD80FFBEB0494961E8 /* KWFailure.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFailure.m; path = Classes/Core/KWFailure.m; sourceTree = "<group>"; };
+		609459F56B11A147E435C7BC /* KWNilMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNilMatcher.h; path = Classes/Matchers/KWNilMatcher.h; sourceTree = "<group>"; };
+		61C1663E2160FAA98037DE6A /* HNKGooglePlacesAutocompletePlaceSubstring.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlaceSubstring.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceSubstring.m; sourceTree = "<group>"; };
+		62C2A88DAADE5C3334920C2A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig"; sourceTree = "<group>"; };
+		6310F6675AF4AD7BE7692B6C /* KWInvocationCapturer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWInvocationCapturer.h; path = Classes/Core/KWInvocationCapturer.h; sourceTree = "<group>"; };
+		631F4A85166DA19B140AAF06 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		642C5B37B895F37327898670 /* KWNull.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNull.m; path = Classes/Core/KWNull.m; sourceTree = "<group>"; };
+		648E7639AF9E1840296F29D8 /* KWAny.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAny.h; path = Classes/Core/KWAny.h; sourceTree = "<group>"; };
+		66DEAEF269DC1D1A4F91E3D5 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
+		6714CE962A2745BAA0576AEF /* KWBeforeAllNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeforeAllNode.h; path = Classes/Nodes/KWBeforeAllNode.h; sourceTree = "<group>"; };
+		672941BAEBA7C288214F67CB /* KWPendingNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWPendingNode.h; path = Classes/Nodes/KWPendingNode.h; sourceTree = "<group>"; };
+		6783109AFC231C57654FDCDD /* KWIntercept.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWIntercept.h; path = Classes/Stubbing/KWIntercept.h; sourceTree = "<group>"; };
+		681D36712B129F452C828D4F /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperation.h; path = AFNetworking/AFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		6875F04EABC52730FF7ED0B7 /* KWMock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMock.m; path = Classes/Mocking/KWMock.m; sourceTree = "<group>"; };
+		68C09A24E35AB2ADAF91B5AA /* KWBeKindOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeKindOfClassMatcher.m; path = Classes/Matchers/KWBeKindOfClassMatcher.m; sourceTree = "<group>"; };
+		69DBFCE1E3C8DC198EBF4C70 /* NSDictionary+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+MTLManipulationAdditions.h"; path = "Mantle/NSDictionary+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		6B1AA6A5F002A393C1173972 /* NSObject+KiwiMockAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiMockAdditions.m"; path = "Classes/Mocking/NSObject+KiwiMockAdditions.m"; sourceTree = "<group>"; };
+		6BB837219F4642C7538C4B31 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m"; sourceTree = "<group>"; };
+		6F578B61DB81E4DA73EC94D7 /* NSDictionary+MTLManipulationAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+MTLManipulationAdditions.m"; path = "Mantle/NSDictionary+MTLManipulationAdditions.m"; sourceTree = "<group>"; };
+		6FBC78BD791745122AE2D0E9 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch"; sourceTree = "<group>"; };
+		70ED2D2CEDEA4D16924EA6BB /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		7141F71B45711513E9CDC94C /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		7143620875F27942A27163AC /* KWUserDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWUserDefinedMatcher.h; path = Classes/Matchers/KWUserDefinedMatcher.h; sourceTree = "<group>"; };
+		7155218DCB2550B1CEE2AB69 /* KWMock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMock.h; path = Classes/Mocking/KWMock.h; sourceTree = "<group>"; };
+		7202A4CC5371FC608B616698 /* KWMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatchers.h; path = Classes/Core/KWMatchers.h; sourceTree = "<group>"; };
+		721B7DF2174B45CD235D4BDC /* KWBeIdenticalToMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeIdenticalToMatcher.m; path = Classes/Matchers/KWBeIdenticalToMatcher.m; sourceTree = "<group>"; };
+		722133A952407EED89644AFA /* KWCaptureSpy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWCaptureSpy.m; path = Classes/Core/KWCaptureSpy.m; sourceTree = "<group>"; };
+		72B7B71AE14FD98605BA7FD1 /* KWContainStringMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContainStringMatcher.h; path = Classes/Matchers/KWContainStringMatcher.h; sourceTree = "<group>"; };
+		733E69147B12A91C3D2F7469 /* KWExampleNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleNode.h; path = Classes/Nodes/KWExampleNode.h; sourceTree = "<group>"; };
+		73EB38A2BAC393BD701C1DEC /* KWAsyncVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAsyncVerifier.h; path = Classes/Verifiers/KWAsyncVerifier.h; sourceTree = "<group>"; };
+		7427F066E7CC974C9AA63BEE /* KWMessagePattern.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMessagePattern.h; path = Classes/Core/KWMessagePattern.h; sourceTree = "<group>"; };
+		76201B007C317EF01040913A /* KWBeforeEachNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeforeEachNode.h; path = Classes/Nodes/KWBeforeEachNode.h; sourceTree = "<group>"; };
+		76ABD82BC4AEB8CA257C99AD /* KWExampleSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExampleSuiteBuilder.m; path = Classes/Core/KWExampleSuiteBuilder.m; sourceTree = "<group>"; };
+		79451FB8991C23B35C99512A /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		79AC4F574E1DE55327C639F1 /* KWPendingNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWPendingNode.m; path = Classes/Nodes/KWPendingNode.m; sourceTree = "<group>"; };
+		7A53DAAAF8D2724A47AE6831 /* KWBeMemberOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeMemberOfClassMatcher.h; path = Classes/Matchers/KWBeMemberOfClassMatcher.h; sourceTree = "<group>"; };
+		7BB55FEA6D2072567D92439A /* KWGenericMatchingAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatchingAdditions.h; path = Classes/Matchers/KWGenericMatchingAdditions.h; sourceTree = "<group>"; };
+		7D39E3712995787F8D1F82DB /* KWSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSpec.m; path = Classes/Core/KWSpec.m; sourceTree = "<group>"; };
+		7D6D2BA4436C9C225AE57149 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		7DD1C8E0A676D4A26022970E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig"; sourceTree = "<group>"; };
+		7E2AE3B9FB94EE7E53A3159F /* AFHTTPRequestOperationManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperationManager.h; path = AFNetworking/AFHTTPRequestOperationManager.h; sourceTree = "<group>"; };
+		7E40F098BD92D7DFDD394295 /* KWItNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWItNode.h; path = Classes/Nodes/KWItNode.h; sourceTree = "<group>"; };
+		81D01AC5EC422EFF65314554 /* KWBeSubclassOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeSubclassOfClassMatcher.h; path = Classes/Matchers/KWBeSubclassOfClassMatcher.h; sourceTree = "<group>"; };
+		82267DB3CB3C73201A6665A9 /* NSObject+MTLComparisonAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MTLComparisonAdditions.h"; path = "Mantle/NSObject+MTLComparisonAdditions.h"; sourceTree = "<group>"; };
+		8261FF9B09EA091684208DD8 /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
+		83145D49F73F827A91190911 /* MTLValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLValueTransformer.h; path = Mantle/MTLValueTransformer.h; sourceTree = "<group>"; };
+		832416BFE0EAE3B092938115 /* KWAsyncVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAsyncVerifier.m; path = Classes/Verifiers/KWAsyncVerifier.m; sourceTree = "<group>"; };
+		84C3A374221D18C941907873 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		85440B27C3A6125225C6C922 /* KWAny.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAny.m; path = Classes/Core/KWAny.m; sourceTree = "<group>"; };
+		85C7ED0C4428EF79DDFA27D2 /* NSObject+KiwiMockAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiMockAdditions.h"; path = "Classes/Mocking/NSObject+KiwiMockAdditions.h"; sourceTree = "<group>"; };
+		86741A9B02D0B6489158FF14 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh"; sourceTree = "<group>"; };
+		8689A6EB65C152EC31D9351B /* KWBeZeroMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeZeroMatcher.m; path = Classes/Matchers/KWBeZeroMatcher.m; sourceTree = "<group>"; };
+		87FD7A0C64A9B19CC92DE663 /* KWWorkarounds.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWWorkarounds.m; path = Classes/Core/KWWorkarounds.m; sourceTree = "<group>"; };
+		87FE19C4EF4405A7CA75D53D /* KWBlockNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBlockNode.h; path = Classes/Nodes/KWBlockNode.h; sourceTree = "<group>"; };
+		885E4D24A736984173D49371 /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = Mantle/extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
+		88ACEE277F8D5693394E79D0 /* KWSuiteConfigurationBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSuiteConfigurationBase.h; path = Classes/Config/KWSuiteConfigurationBase.h; sourceTree = "<group>"; };
+		8AF39182295F17216598BB7A /* NSInvocation+OCMAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+OCMAdditions.h"; path = "Classes/Core/NSInvocation+OCMAdditions.h"; sourceTree = "<group>"; };
+		8B715902432199163C644C9C /* KWUserDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWUserDefinedMatcher.m; path = Classes/Matchers/KWUserDefinedMatcher.m; sourceTree = "<group>"; };
+		8BA5EA7F6390A5FD58B503C1 /* KWConformToProtocolMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWConformToProtocolMatcher.m; path = Classes/Matchers/KWConformToProtocolMatcher.m; sourceTree = "<group>"; };
+		8C0909B2DEB2A012C7D90EFE /* MTLManagedObjectAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLManagedObjectAdapter.m; path = Mantle/MTLManagedObjectAdapter.m; sourceTree = "<group>"; };
+		8C5242FE5C1098CB27DC77CA /* KWSymbolicator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWSymbolicator.m; path = Classes/Core/KWSymbolicator.m; sourceTree = "<group>"; };
+		8CB6EEF5F9A19D94E64AF682 /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		8F4C1C26EF3797C6DB1945A3 /* Pods-HNKGooglePlacesAutocomplete-Example-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-environment.h"; sourceTree = "<group>"; };
+		8F9CFA70131BE2D3F63FFD61 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		9048A10A71BE7350762E5699 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		91D4FE8D1A36492839D2FA40 /* NSObject+KiwiVerifierAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiVerifierAdditions.m"; path = "Classes/Core/NSObject+KiwiVerifierAdditions.m"; sourceTree = "<group>"; };
+		9214CD0A612664E006226CD3 /* KWRegularExpressionPatternMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRegularExpressionPatternMatcher.h; path = Classes/Matchers/KWRegularExpressionPatternMatcher.h; sourceTree = "<group>"; };
+		93747B5D2398EB141394C75C /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = Mantle/extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		95C0A2C1AB05CFFB7DC47385 /* KWRespondToSelectorMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWRespondToSelectorMatcher.h; path = Classes/Matchers/KWRespondToSelectorMatcher.h; sourceTree = "<group>"; };
+		979371E2DC3BCA3C1F8E9DC9 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLConnectionOperation.h; path = AFNetworking/AFURLConnectionOperation.h; sourceTree = "<group>"; };
+		979AA37F4938B3003CE4D352 /* KWMatcherFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMatcherFactory.m; path = Classes/Core/KWMatcherFactory.m; sourceTree = "<group>"; };
+		983927CAAFCC097DA87D8147 /* MTLModel+NSCoding.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "MTLModel+NSCoding.m"; path = "Mantle/MTLModel+NSCoding.m"; sourceTree = "<group>"; };
+		9A3381FFD966F8078306796A /* KWContextNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContextNode.h; path = Classes/Nodes/KWContextNode.h; sourceTree = "<group>"; };
+		9B3971D7A328368B1EFDABA2 /* KWGenericMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatcher.h; path = Classes/Matchers/KWGenericMatcher.h; sourceTree = "<group>"; };
+		9B936D8CB942A5A56CD2976A /* KWAllTestsSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAllTestsSuite.m; path = Classes/Config/KWAllTestsSuite.m; sourceTree = "<group>"; };
+		9BD1FCEAA03B2F2473C5E869 /* KWGenericMatchingAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWGenericMatchingAdditions.m; path = Classes/Matchers/KWGenericMatchingAdditions.m; sourceTree = "<group>"; };
+		9C6885FE1918B1D5FCCB5BD3 /* KWCaptureSpy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWCaptureSpy.h; path = Classes/Core/KWCaptureSpy.h; sourceTree = "<group>"; };
+		9D5C9C6007FD154C2964D3D2 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		9E2CDA446D629F7EAB891CCB /* KWExampleSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleSuite.h; path = Classes/Core/KWExampleSuite.h; sourceTree = "<group>"; };
+		9F19D47C11FB1B1D3A48D833 /* NSProxy+KiwiVerifierAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSProxy+KiwiVerifierAdditions.m"; path = "Classes/Core/NSProxy+KiwiVerifierAdditions.m"; sourceTree = "<group>"; };
+		A18399ECE4AFBFE094A610CA /* Mantle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mantle.h; path = Mantle/Mantle.h; sourceTree = "<group>"; };
+		A1BA14C28082DEBAA8A2C0D3 /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
+		A2539A48472FC403B1233EEA /* HNKGooglePlacesAutocompletePlaceTerm.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlaceTerm.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceTerm.m; sourceTree = "<group>"; };
+		A26E260C9799159DA7092A33 /* KWNotificationMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWNotificationMatcher.m; path = Classes/Matchers/KWNotificationMatcher.m; sourceTree = "<group>"; };
+		A34FFD6DE4AB76C387CC95CD /* MTLValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLValueTransformer.m; path = Mantle/MTLValueTransformer.m; sourceTree = "<group>"; };
+		A426309C2869CC9FAC706FFF /* KWInvocationCapturer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWInvocationCapturer.m; path = Classes/Core/KWInvocationCapturer.m; sourceTree = "<group>"; };
+		A4F915DB034209E392AA4CA3 /* KWInequalityMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWInequalityMatcher.h; path = Classes/Matchers/KWInequalityMatcher.h; sourceTree = "<group>"; };
+		A5481AF1ECA95BFAC435F7A5 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		A682B6D0E7FA9F7271385591 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig"; sourceTree = "<group>"; };
+		A8269E21D05170FF6B63BB4A /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB274ADFC1EDD20DFCE0EB4E /* KWExampleNodeVisitor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleNodeVisitor.h; path = Classes/Core/KWExampleNodeVisitor.h; sourceTree = "<group>"; };
+		ABB8D740959AD367214CCB1C /* KWBeIdenticalToMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeIdenticalToMatcher.h; path = Classes/Matchers/KWBeIdenticalToMatcher.h; sourceTree = "<group>"; };
+		ABBA83830116B5FB194FAA1E /* KWStringUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStringUtilities.h; path = Classes/Core/KWStringUtilities.h; sourceTree = "<group>"; };
+		AD657064F8AF2E5C24290147 /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = Mantle/extobjc/EXTScope.m; sourceTree = "<group>"; };
+		ADACF9CDCD8D0F37A34CEEE4 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperation.m; path = AFNetworking/AFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		AE01E1A98E0603E4F08E369B /* KWBeTrueMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeTrueMatcher.h; path = Classes/Matchers/KWBeTrueMatcher.h; sourceTree = "<group>"; };
+		AF2F31E6BF07EA57DAF28CCB /* KWBeTrueMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeTrueMatcher.m; path = Classes/Matchers/KWBeTrueMatcher.m; sourceTree = "<group>"; };
+		B02627A56270D96908F77373 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B0C87521FCE58537C2E0EE76 /* KWRegularExpressionPatternMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRegularExpressionPatternMatcher.m; path = Classes/Matchers/KWRegularExpressionPatternMatcher.m; sourceTree = "<group>"; };
+		B0D49FF0C2E69758A6F0A435 /* KWReceiveMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWReceiveMatcher.m; path = Classes/Matchers/KWReceiveMatcher.m; sourceTree = "<group>"; };
+		B0FB42ABA492CA445BA8D806 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig"; sourceTree = "<group>"; };
+		B10DFB26BF441674BF454A31 /* KWStub.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWStub.h; path = Classes/Stubbing/KWStub.h; sourceTree = "<group>"; };
+		B1430EC7B7A6822CEE24DA53 /* KWExampleDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExampleDelegate.h; path = Classes/Core/KWExampleDelegate.h; sourceTree = "<group>"; };
+		B16E782834CDAA835A3AEE2A /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		B275B49BD82B42FBB1AC384B /* MTLJSONAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLJSONAdapter.h; path = Mantle/MTLJSONAdapter.h; sourceTree = "<group>"; };
+		B29016C0A3DFEA6B205E6EAD /* KWAfterEachNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAfterEachNode.m; path = Classes/Nodes/KWAfterEachNode.m; sourceTree = "<group>"; };
+		B4B0F593C56E23FB94DA5595 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
+		B5153FCD9051E88E07060C18 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig"; sourceTree = "<group>"; };
+		B51820D96C5D0E156605C33C /* NSArray+MTLManipulationAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+MTLManipulationAdditions.h"; path = "Mantle/NSArray+MTLManipulationAdditions.h"; sourceTree = "<group>"; };
+		B5A7D5BBC2D95B105E40727D /* KWInequalityMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWInequalityMatcher.m; path = Classes/Matchers/KWInequalityMatcher.m; sourceTree = "<group>"; };
+		B7018060801AB9C046436C71 /* KiwiMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiMacros.h; path = Classes/Core/KiwiMacros.h; sourceTree = "<group>"; };
+		B72F8CC36CF3EF7BF883CD71 /* KWContainStringMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContainStringMatcher.m; path = Classes/Matchers/KWContainStringMatcher.m; sourceTree = "<group>"; };
+		B93B3747BF28C0DC7F495048 /* CLPlacemark+HNKAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CLPlacemark+HNKAdditions.h"; path = "Pod/Classes/CLPlacemark+HNKAdditions.h"; sourceTree = "<group>"; };
+		B97D087AB1CBFC2AE12B6E8A /* KWBeSubclassOfClassMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeSubclassOfClassMatcher.m; path = Classes/Matchers/KWBeSubclassOfClassMatcher.m; sourceTree = "<group>"; };
+		BA5924D68145C49E5C943F8C /* HNKServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKServer.h; path = Pod/Classes/HNKServer.h; sourceTree = "<group>"; };
+		BD3B5C6C5E858E10AD8375E7 /* KWHaveValueMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWHaveValueMatcher.h; path = Classes/Matchers/KWHaveValueMatcher.h; sourceTree = "<group>"; };
+		BD4153A19B0C1B9B18C9C291 /* KWAfterAllNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWAfterAllNode.m; path = Classes/Nodes/KWAfterAllNode.m; sourceTree = "<group>"; };
+		BE1BF96547435A8130BC87F3 /* CLPlacemark+HNKAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CLPlacemark+HNKAdditions.m"; path = "Pod/Classes/CLPlacemark+HNKAdditions.m"; sourceTree = "<group>"; };
+		BF3B00A9B5261E8F00DCAD73 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		BF5D10DF5C2F0ED786CDD31C /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m"; sourceTree = "<group>"; };
+		BFB415FBCBBCD15E98C25BA2 /* KiwiConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KiwiConfiguration.h; path = Classes/Core/KiwiConfiguration.h; sourceTree = "<group>"; };
+		C026BB0B0824CF270DF25F05 /* KWMatchVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWMatchVerifier.h; path = Classes/Verifiers/KWMatchVerifier.h; sourceTree = "<group>"; };
+		C15F918C2E0C6885A74307EB /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
+		C246BD0BDD2017BFFE742136 /* KWBlock.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlock.m; path = Classes/Core/KWBlock.m; sourceTree = "<group>"; };
+		C2610752AC061C6B07B897CA /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist"; sourceTree = "<group>"; };
+		C30D1A79D9BD7E9E7B11F72E /* NSInvocation+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+KiwiAdditions.m"; path = "Classes/Core/NSInvocation+KiwiAdditions.m"; sourceTree = "<group>"; };
+		C3E738B32D1B7A76E18A36D2 /* KWMessagePattern.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMessagePattern.m; path = Classes/Core/KWMessagePattern.m; sourceTree = "<group>"; };
+		C4EB6F8BD01AFDDC98B7B60D /* KWContainMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWContainMatcher.m; path = Classes/Matchers/KWContainMatcher.m; sourceTree = "<group>"; };
+		C5129A5942AD017A33AC8426 /* KWBeEmptyMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeEmptyMatcher.h; path = Classes/Matchers/KWBeEmptyMatcher.h; sourceTree = "<group>"; };
+		C51E500A571D652D9BB558CC /* KWExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExample.m; path = Classes/Core/KWExample.m; sourceTree = "<group>"; };
+		C5ECF20F98365807824D5A80 /* KWExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExample.h; path = Classes/Core/KWExample.h; sourceTree = "<group>"; };
+		C6179FCBD8AEEA8636E75610 /* NSObject+KiwiSpyAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiSpyAdditions.m"; path = "Classes/Core/NSObject+KiwiSpyAdditions.m"; sourceTree = "<group>"; };
+		C68045EBC5A99E5C108F24C6 /* KWIntercept.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWIntercept.m; path = Classes/Stubbing/KWIntercept.m; sourceTree = "<group>"; };
+		C6AACF1C5AF6C2F26A88ADF9 /* NSObject+KiwiSpyAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiSpyAdditions.h"; path = "Classes/Core/NSObject+KiwiSpyAdditions.h"; sourceTree = "<group>"; };
+		C70A82B07335BBE631FC70DA /* KWExistVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExistVerifier.m; path = Classes/Verifiers/KWExistVerifier.m; sourceTree = "<group>"; };
+		C725026B8D6C6812560B24FE /* KWAfterAllNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWAfterAllNode.h; path = Classes/Nodes/KWAfterAllNode.h; sourceTree = "<group>"; };
+		C8224EBBC7A835A7DA27BE73 /* KWGenericMatchEvaluator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWGenericMatchEvaluator.h; path = Classes/Matchers/KWGenericMatchEvaluator.h; sourceTree = "<group>"; };
+		C87B40101D918DBE3560083F /* KWContainMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWContainMatcher.h; path = Classes/Matchers/KWContainMatcher.h; sourceTree = "<group>"; };
+		C907D7980FC98B5B5B565692 /* KWExistVerifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWExistVerifier.h; path = Classes/Verifiers/KWExistVerifier.h; sourceTree = "<group>"; };
+		CCF4D2B2B1B0793E2F40EF87 /* KWLet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWLet.h; path = Classes/Core/KWLet.h; sourceTree = "<group>"; };
+		CDE90FCDE593FB3F346B9EF2 /* HNKGooglePlacesAutocompleteQueryConfig.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQueryConfig.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryConfig.h; sourceTree = "<group>"; };
+		CE5F9399F060572F99866945 /* KWHaveMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWHaveMatcher.h; path = Classes/Matchers/KWHaveMatcher.h; sourceTree = "<group>"; };
+		CEDAB7C76B23C7810E2BB464 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
+		CF1532FE6B9561F3DBAD8D33 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch"; sourceTree = "<group>"; };
+		CFBCE7C2CB68A01857DD0A64 /* NSError+MTLModelException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+MTLModelException.h"; path = "Mantle/NSError+MTLModelException.h"; sourceTree = "<group>"; };
+		D0354A1F8D5A2E496BF1F3CE /* HNKGooglePlacesAutocompleteQueryConfig.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQueryConfig.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryConfig.m; sourceTree = "<group>"; };
+		D1ADE9D07A80471786246DAA /* KWWorkarounds.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWWorkarounds.h; path = Classes/Core/KWWorkarounds.h; sourceTree = "<group>"; };
+		D1B81239511CEE949C339D0C /* KWBlockNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBlockNode.m; path = Classes/Nodes/KWBlockNode.m; sourceTree = "<group>"; };
+		D20A6E820FE0F89BCCD20879 /* HNKGooglePlacesAutocompleteQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompleteQuery.m; path = Pod/Classes/HNKGooglePlacesAutocompleteQuery.m; sourceTree = "<group>"; };
+		D252F0F6E6E6678CA1E5D9D3 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D432B5A3263BFD43852C7632 /* KWReporting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWReporting.h; path = Classes/Core/KWReporting.h; sourceTree = "<group>"; };
+		D56A58B71A5EACA5D252F3B2 /* KWStub.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStub.m; path = Classes/Stubbing/KWStub.m; sourceTree = "<group>"; };
+		D6A97C20A6FA8F514F98C226 /* NSValue+KiwiAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+KiwiAdditions.m"; path = "Classes/Core/NSValue+KiwiAdditions.m"; sourceTree = "<group>"; };
+		D8ED5C06FB8AA26D350BF759 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		DA65AEE5BCAE9E492256C16C /* KWBeforeEachNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeforeEachNode.m; path = Classes/Nodes/KWBeforeEachNode.m; sourceTree = "<group>"; };
+		DE28C0DC91CDAC07DE709042 /* KWObjCUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWObjCUtilities.m; path = Classes/Core/KWObjCUtilities.m; sourceTree = "<group>"; };
+		E09E45B5C5CD1693D1E21AC9 /* HNKServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKServer.m; path = Pod/Classes/HNKServer.m; sourceTree = "<group>"; };
+		E1F0E450100A8B8451D13A32 /* KWNull.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWNull.h; path = Classes/Core/KWNull.h; sourceTree = "<group>"; };
+		E2C44ED22FBB9178AAA07397 /* KWSymbolicator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWSymbolicator.h; path = Classes/Core/KWSymbolicator.h; sourceTree = "<group>"; };
+		E4545C08DE9A561A278D8197 /* HNKGooglePlacesAutocompletePlace.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = HNKGooglePlacesAutocompletePlace.m; path = Pod/Classes/HNKGooglePlacesAutocompletePlace.m; sourceTree = "<group>"; };
+		E473DF1FB362FD896BAAD5F7 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		E5F823084A1FBC33E9F0872C /* KWBeWithinMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeWithinMatcher.m; path = Classes/Matchers/KWBeWithinMatcher.m; sourceTree = "<group>"; };
+		E685C07400862F0C43753B6F /* KWVerifying.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWVerifying.h; path = Classes/Verifiers/KWVerifying.h; sourceTree = "<group>"; };
+		E706A16A7639546A99250947 /* KWFailure.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWFailure.h; path = Classes/Core/KWFailure.h; sourceTree = "<group>"; };
+		E748C07296161769F7B1F78C /* KWStringPrefixMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringPrefixMatcher.m; path = Classes/Matchers/KWStringPrefixMatcher.m; sourceTree = "<group>"; };
+		EA061D9CAE43EE7F7CCE08A7 /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = Mantle/extobjc/metamacros.h; sourceTree = "<group>"; };
+		EAD947AD8E4E42CC4CD9CCAF /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLConnectionOperation.m; path = AFNetworking/AFURLConnectionOperation.m; sourceTree = "<group>"; };
+		EB9D5E32969C075AF7602E44 /* KWBeBetweenMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeBetweenMatcher.h; path = Classes/Matchers/KWBeBetweenMatcher.h; sourceTree = "<group>"; };
+		EC74E98383875E4506A5AD02 /* NSProxy+KiwiVerifierAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSProxy+KiwiVerifierAdditions.h"; path = "Classes/Core/NSProxy+KiwiVerifierAdditions.h"; sourceTree = "<group>"; };
+		ECFB003F2BAEFD9189A14C5F /* NSValueTransformer+MTLInversionAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValueTransformer+MTLInversionAdditions.m"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.m"; sourceTree = "<group>"; };
+		EE678E462836A712323417D0 /* KWExampleSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWExampleSuite.m; path = Classes/Core/KWExampleSuite.m; sourceTree = "<group>"; };
+		EECEAC192D4F7CFCBE45E6D8 /* MTLModel+NSCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "MTLModel+NSCoding.h"; path = "Mantle/MTLModel+NSCoding.h"; sourceTree = "<group>"; };
+		EEEEAE22321993C912C05D85 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		EF1EF0A919CA66089DEFCE42 /* KWDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWDeviceInfo.m; path = Classes/Core/KWDeviceInfo.m; sourceTree = "<group>"; };
+		EFAE34CC9D335DE772BDAA8B /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		F112277E31042594585ED74D /* NSValue+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+KiwiAdditions.h"; path = "Classes/Core/NSValue+KiwiAdditions.h"; sourceTree = "<group>"; };
+		F143E90D486F63985C039631 /* NSObject+KiwiStubAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+KiwiStubAdditions.m"; path = "Classes/Stubbing/NSObject+KiwiStubAdditions.m"; sourceTree = "<group>"; };
+		F1E2D7F256FB4DE806130029 /* libPods-HNKGooglePlacesAutocomplete-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HNKGooglePlacesAutocomplete-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2EC69AA85ADAAB1B04F70D8 /* NSObject+KiwiVerifierAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+KiwiVerifierAdditions.h"; path = "Classes/Core/NSObject+KiwiVerifierAdditions.h"; sourceTree = "<group>"; };
+		F4787184CE58BDEA445AADAD /* KWRespondToSelectorMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWRespondToSelectorMatcher.m; path = Classes/Matchers/KWRespondToSelectorMatcher.m; sourceTree = "<group>"; };
+		F4F1A003FBAE439D59C5416B /* HNKGooglePlacesAutocompletePlaceSubstring.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompletePlaceSubstring.h; path = Pod/Classes/HNKGooglePlacesAutocompletePlaceSubstring.h; sourceTree = "<group>"; };
+		F4F3F6D856E0B9DC7101F9C6 /* KWBeEmptyMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeEmptyMatcher.m; path = Classes/Matchers/KWBeEmptyMatcher.m; sourceTree = "<group>"; };
+		F57C5A7D2D81698AB8BC3015 /* KWFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWFormatter.m; path = Classes/Core/KWFormatter.m; sourceTree = "<group>"; };
+		F695E5FD177B4B9EDDD99322 /* KWProbePoller.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWProbePoller.h; path = Classes/Core/KWProbePoller.h; sourceTree = "<group>"; };
+		F82CE9C50DE2EB5D6275BFF3 /* KWMessageTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWMessageTracker.m; path = Classes/Core/KWMessageTracker.m; sourceTree = "<group>"; };
+		F844BBF4F25054BEC88197CA /* NSMethodSignature+KiwiAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+KiwiAdditions.h"; path = "Classes/Core/NSMethodSignature+KiwiAdditions.h"; sourceTree = "<group>"; };
+		F97DFFB47534E266982015BE /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		F9AA4351CF37E9A005EA9238 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		FA6DF0081E492323DE15D506 /* MTLModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MTLModel.h; path = Mantle/MTLModel.h; sourceTree = "<group>"; };
+		FB0918F41F27FEA1BCFF783F /* KWStringUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWStringUtilities.m; path = Classes/Core/KWStringUtilities.m; sourceTree = "<group>"; };
+		FB27E0CAF2A6DB42D5C344FF /* NSValueTransformer+MTLInversionAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValueTransformer+MTLInversionAdditions.h"; path = "Mantle/NSValueTransformer+MTLInversionAdditions.h"; sourceTree = "<group>"; };
+		FBBD71D5F2DD9BA199F190F7 /* MTLJSONAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLJSONAdapter.m; path = Mantle/MTLJSONAdapter.m; sourceTree = "<group>"; };
+		FCD71CD7B5300FD2ADFE8A2A /* HNKGooglePlacesAutocompleteQueryResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = HNKGooglePlacesAutocompleteQueryResponse.h; path = Pod/Classes/HNKGooglePlacesAutocompleteQueryResponse.h; sourceTree = "<group>"; };
+		FCE4CAFB2A8AD604A2301A11 /* MTLReflection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MTLReflection.m; path = Mantle/MTLReflection.m; sourceTree = "<group>"; };
+		FD70C4363BD69C147DCB7C19 /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		FD9AF4CECF327CA8CA695C94 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch"; sourceTree = "<group>"; };
+		FE2DFC6A8F7A0336FD47E80B /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig"; sourceTree = "<group>"; };
+		FEB132241245662CB0C76262 /* KWBeforeAllNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KWBeforeAllNode.m; path = Classes/Nodes/KWBeforeAllNode.m; sourceTree = "<group>"; };
+		FEB620D3654708659FE5CF5D /* Pods-HNKGooglePlacesAutocomplete-Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-HNKGooglePlacesAutocomplete-Example-resources.sh"; sourceTree = "<group>"; };
+		FFF2F31246B4580FF518BA05 /* KWBeKindOfClassMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KWBeKindOfClassMatcher.h; path = Classes/Matchers/KWBeKindOfClassMatcher.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		21A2BBDF5041D8496B6C18AF /* Frameworks */ = {
+		106D2C75BBA57256C2C1A6B0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6DB6A6A7C2B3B6A9B5F370CD /* Foundation.framework in Frameworks */,
+				6E4A190BDCA0AF1F595C9498 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5271CCBD72CCF3B6EA2FA1CF /* Frameworks */ = {
+		3352B6614B6D2A42C044BA00 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58A8421984339353EB259CC2 /* CoreGraphics.framework in Frameworks */,
-				4E5A56FD48AEDA33B351E8B7 /* Foundation.framework in Frameworks */,
-				D72F192F38EBB07F07B7B0D7 /* MobileCoreServices.framework in Frameworks */,
-				75CECEA8EBBDB3B00AEBBAD6 /* Security.framework in Frameworks */,
-				460CBF854FBD4E1F5914BBDB /* SystemConfiguration.framework in Frameworks */,
+				2EEF7469701823D89CF96D0C /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		643E8C20794C365D15AC58A6 /* Frameworks */ = {
+		59B422518A576CDF9FC9F636 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE3882283BC47BCFB107C2DF /* Foundation.framework in Frameworks */,
+				38351128BEDC44F9EE969055 /* Foundation.framework in Frameworks */,
+				F9E17CF2E14BD16E04AD9254 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6BDBE5C49A46035FEECEC98C /* Frameworks */ = {
+		9CECE295E022682617BF3547 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				97B2B8B42BDB3DA1113A0C42 /* Foundation.framework in Frameworks */,
-				4B3C634774D8B3CDA65EA8D7 /* XCTest.framework in Frameworks */,
+				A4FB8917D103AB573F93DE60 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AD3D5012AC6B32032A1ED830 /* Frameworks */ = {
+		A049745E2F9029125C7679BE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2A449D3A52223981A60DBC7 /* Foundation.framework in Frameworks */,
+				13627F7D0DDB8F9DD37338F7 /* CoreGraphics.framework in Frameworks */,
+				F64A653EF051FD95390F6E79 /* Foundation.framework in Frameworks */,
+				7077C68A4535778661A25C28 /* MobileCoreServices.framework in Frameworks */,
+				05C99878E8FD9517D02C4076 /* Security.framework in Frameworks */,
+				1BB73F9C76D26B0C190597F8 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B369382AE863B8F9D3A10F98 /* Frameworks */ = {
+		B59A1395DFC09827557C63FC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B33D41AF4B007DBDAF6EEABC /* Foundation.framework in Frameworks */,
+				C3FF90C4F72000DDAE96D424 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FA2FDFB6F07A2D987118EC06 /* Frameworks */ = {
+		CB82BE4CBE6D5D4E71D2F8C1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				732919E0DDB015B7FDB6783B /* Foundation.framework in Frameworks */,
+				428BE6FA257DDDB74393798D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0FC5CB945CF2069D4FCFAF64 /* HNKGooglePlacesAutocomplete */ = {
+		08C437091181E4DCCCDF1E4B /* Serialization */ = {
 			isa = PBXGroup;
 			children = (
-				75B305FBE817D0666537DCB0 /* CLPlacemark+HNKAdditions.h */,
-				02ABA1AEC8FD8F076DF71180 /* CLPlacemark+HNKAdditions.m */,
-				E62C7358155AD7ABC39F5660 /* HNKGooglePlacesAutocomplete.h */,
-				160D004B1AD890254F08B4AF /* Models */,
-				C2E66DAD548BB5FA8A627DF2 /* Support Files */,
-			);
-			path = HNKGooglePlacesAutocomplete;
-			sourceTree = "<group>";
-		};
-		105C69EBA195A22C4E48F115 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				ABF9EEA94EB3308D118795DC /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		160D004B1AD890254F08B4AF /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				B28DE78EEE80838E012C7B0F /* HNKGooglePlacesAutocompleteModel.h */,
-				E14D398200422A4E56663811 /* HNKGooglePlacesAutocompleteModel.m */,
-				BBF123EFFF84231EBE704A71 /* HNKGooglePlacesAutocompletePlace.h */,
-				7DCAEF6BA13B2C07DE1B3AB2 /* HNKGooglePlacesAutocompletePlace.m */,
-				DD0C618A00A60E95D57CB846 /* HNKGooglePlacesAutocompletePlaceSubstring.h */,
-				DB0A3962E173AFB8ABF85897 /* HNKGooglePlacesAutocompletePlaceSubstring.m */,
-				EBF98612B0897213DD578979 /* HNKGooglePlacesAutocompletePlaceTerm.h */,
-				73C9A96186E0625E38A62900 /* HNKGooglePlacesAutocompletePlaceTerm.m */,
-				CD05CAFA709E112E89C22030 /* HNKGooglePlacesAutocompleteQuery.h */,
-				8BA0D05990AE655DBC165CA3 /* HNKGooglePlacesAutocompleteQuery.m */,
-				C849A5EEE47D2960A2EED7ED /* HNKGooglePlacesAutocompleteQueryConfig.h */,
-				F5AE4FB643934531473F9160 /* HNKGooglePlacesAutocompleteQueryConfig.m */,
-				31D6F826354B442AB08808D9 /* HNKGooglePlacesAutocompleteQueryResponse.h */,
-				AFDA29167395549A876336AB /* HNKGooglePlacesAutocompleteQueryResponse.m */,
-				4E81E77D4C21E13FC8B070C6 /* Networking */,
-			);
-			name = Models;
-			sourceTree = "<group>";
-		};
-		1DB5BE5E55305869B7F2AB2E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				EE7A9058CDD102A5B6C74A36 /* libPods-HNKGooglePlacesAutocomplete-Example.a */,
-				9327B768AF5A3B77476DAAC6 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */,
-				3841EF67FE7179A68A84E0AE /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */,
-				CD57BDC361AF3A229800C9E8 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */,
-				1D99D6813A6071660B5ED853 /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */,
-				671B91C3BA65219D4629CAD9 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */,
-				3C0B2189DE86ED20A3BAD445 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		1E39826096790DF13D51A19E /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */ = {
-			isa = PBXGroup;
-			children = (
-				0FA75141F2FF010DCD49371F /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown */,
-				AB509B781FD98D50B689B528 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist */,
-				3600247DEF721527846D6E97 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */,
-				55899EC1EE25F7A4B0239DA3 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h */,
-				F0CA13ADB263ACC181A08177 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh */,
-				1BE89C7599E344BA6D699F26 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */,
-				AF2BF1DE1D58442CD08EC0C0 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
-			path = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests";
-			sourceTree = "<group>";
-		};
-		1E9A406B84CA4EE975D00F3E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				63548B2FA45B9E7BEFEB4DEE /* AFNetworking */,
-				0FC5CB945CF2069D4FCFAF64 /* HNKGooglePlacesAutocomplete */,
-				CF8D314CD976BE28CAB2D6AE /* HNKServerFacade */,
-				6E29B6C9C3AF771D67D89DE5 /* Kiwi */,
-				69BC97C95A888800C2759A77 /* Mantle */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		3B812DFE6D924704FDE4BF74 /* Serialization */ = {
-			isa = PBXGroup;
-			children = (
-				D8AAF812744AA4E992973552 /* AFURLRequestSerialization.h */,
-				C1C32F33088BD57D15678ED2 /* AFURLRequestSerialization.m */,
-				F2FADAACB261E7B8C528B2A3 /* AFURLResponseSerialization.h */,
-				CA4899804A758DF0ADCB4951 /* AFURLResponseSerialization.m */,
+				12268B1FAAF4DD67D8F90ED3 /* AFURLRequestSerialization.h */,
+				A5481AF1ECA95BFAC435F7A5 /* AFURLRequestSerialization.m */,
+				29E19316023814B3DF17CC6C /* AFURLResponseSerialization.h */,
+				8CB6EEF5F9A19D94E64AF682 /* AFURLResponseSerialization.m */,
 			);
 			name = Serialization;
 			sourceTree = "<group>";
 		};
-		45332509B3B1EA9470AE859B /* Support Files */ = {
+		1C6097F0DE29AF308915F0A1 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				4F0617556051049CE3782ED9 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig */,
-				8B57D6EA1B7AAD8217DF422C /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */,
-				C2D031CC4916ED55FC3A0AFD /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */,
-				885D02036C980A5BD90474AE /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch */,
+				B5153FCD9051E88E07060C18 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking.xcconfig */,
+				A682B6D0E7FA9F7271385591 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */,
+				07452410253F30793CC25F31 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m */,
+				CF1532FE6B9561F3DBAD8D33 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
 			sourceTree = "<group>";
 		};
-		4E81E77D4C21E13FC8B070C6 /* Networking */ = {
+		1F76060D038DCA3CBA054CE3 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				366814AEF59CB4783023E14A /* HNKGooglePlacesServer.h */,
-				22D05E3531D5FF919FC6E6DA /* HNKGooglePlacesServer.m */,
-			);
-			name = Networking;
-			sourceTree = "<group>";
-		};
-		5F0E034A9535F160FC2F16E4 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1EEFAA1C931954784B29D904 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig */,
-				E55B402FF75765CBC664F624 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */,
-				1C9271E5E05D8D5FAC09ACA7 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */,
-				8F18FE0AE4A70EF9C80C4A15 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
-			sourceTree = "<group>";
-		};
-		623FC0E2B90FA9ECD224FEE7 /* Pods-HNKGooglePlacesAutocomplete-Example */ = {
-			isa = PBXGroup;
-			children = (
-				F2D694F13E04E93E9CB358D8 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown */,
-				463DB134D54F5CA56C7B15B2 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist */,
-				BB22393EDB8A17E11272A9D4 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */,
-				32BF47213CD680B37BAAF08F /* Pods-HNKGooglePlacesAutocomplete-Example-environment.h */,
-				C108D3F5C43FA2B278F6D600 /* Pods-HNKGooglePlacesAutocomplete-Example-resources.sh */,
-				7236E956CC48818885C33A91 /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */,
-				D75B074A690D1E34D1DD609E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-Example";
-			path = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example";
-			sourceTree = "<group>";
-		};
-		63548B2FA45B9E7BEFEB4DEE /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				0A9BB0416EFA7222D95EE2DE /* AFNetworking.h */,
-				FEE8D5EC6CE45CE33F47BA0B /* NSURLConnection */,
-				CC5E30576987414474A5802F /* NSURLSession */,
-				9F5E60A50AF3B32E9969406B /* Reachability */,
-				9173E6654CC7EE840B5F3E1D /* Security */,
-				3B812DFE6D924704FDE4BF74 /* Serialization */,
-				45332509B3B1EA9470AE859B /* Support Files */,
-				B02E7D170C46AED865EB951D /* UIKit */,
-			);
-			path = AFNetworking;
-			sourceTree = "<group>";
-		};
-		69BC97C95A888800C2759A77 /* Mantle */ = {
-			isa = PBXGroup;
-			children = (
-				290DD89F0E22EC1A8423CFF6 /* MTLJSONAdapter.h */,
-				B77F89E73CE58FC4DD469316 /* MTLJSONAdapter.m */,
-				B526551D60FA1636B3A7BFE1 /* MTLManagedObjectAdapter.h */,
-				C630E66B948CBA4EB25A0040 /* MTLManagedObjectAdapter.m */,
-				89F18F715860E6BF5FADCA94 /* MTLModel.h */,
-				76AF7A9FF3DA0179AA4D5D16 /* MTLModel.m */,
-				CB5302C1896503B58AA0DD46 /* MTLModel+NSCoding.h */,
-				7B95D45685BA004A661CF0AB /* MTLModel+NSCoding.m */,
-				CB3557CDA61806D6B2598719 /* MTLReflection.h */,
-				9687BE7EE32CA81984436E98 /* MTLReflection.m */,
-				66C3005DEAE02A9C5F534AE5 /* MTLValueTransformer.h */,
-				7EF1418F4699618D44A7C4A1 /* MTLValueTransformer.m */,
-				9F758D3939FA3E07C9564ACF /* Mantle.h */,
-				129389ACC98F2328B0CDD865 /* NSArray+MTLManipulationAdditions.h */,
-				566B17D79DDC937640420057 /* NSArray+MTLManipulationAdditions.m */,
-				1FE9734F16C3F2C0F3934E62 /* NSDictionary+MTLManipulationAdditions.h */,
-				E7E34CCAACC7F15837B2712D /* NSDictionary+MTLManipulationAdditions.m */,
-				6BCC1510FCC6D08CA800CE61 /* NSError+MTLModelException.h */,
-				7E2B3034C8D6C680BD6B3B7B /* NSError+MTLModelException.m */,
-				0E5CAE219A18BD25491B34C9 /* NSObject+MTLComparisonAdditions.h */,
-				A02550277C4B216645124103 /* NSObject+MTLComparisonAdditions.m */,
-				107602048702D57484FD8190 /* NSValueTransformer+MTLInversionAdditions.h */,
-				CD00EFE92810301CEB7BB9B2 /* NSValueTransformer+MTLInversionAdditions.m */,
-				5969993BFC9FB87120828703 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */,
-				2039C37E5E178A4721FCAEEC /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */,
-				D7E3345163A2BD3E28A9F801 /* Support Files */,
-				BBDC715335C9AEDB36F34F8F /* extobjc */,
-			);
-			path = Mantle;
-			sourceTree = "<group>";
-		};
-		6E29B6C9C3AF771D67D89DE5 /* Kiwi */ = {
-			isa = PBXGroup;
-			children = (
-				D0DFA811837E110097548562 /* KWAfterAllNode.h */,
-				C0964C150FEF43E7E4ADCF86 /* KWAfterAllNode.m */,
-				C2FC490D291EB30EA05E1396 /* KWAfterEachNode.h */,
-				03FEAF0F394038598BB17F37 /* KWAfterEachNode.m */,
-				4C071E90A2B093881945E007 /* KWAllTestsSuite.m */,
-				CD3EF45202C88562C1A46E53 /* KWAny.h */,
-				29E999622A0EFB0F197D3F35 /* KWAny.m */,
-				552F7E31625905B16A99DAE1 /* KWAsyncVerifier.h */,
-				6E61E71CF66B835D22D0D59C /* KWAsyncVerifier.m */,
-				6B1CAE77C0A82214EE965418 /* KWBeBetweenMatcher.h */,
-				0B2335F35CEF26E2D86EC55C /* KWBeBetweenMatcher.m */,
-				B823608C11E6630A0D1DD9E6 /* KWBeEmptyMatcher.h */,
-				9D6541B6AEB83DE702D6D462 /* KWBeEmptyMatcher.m */,
-				9D25C95DF8C3FE2C2063D3D0 /* KWBeIdenticalToMatcher.h */,
-				6BD42021E4EE0BC7921758F5 /* KWBeIdenticalToMatcher.m */,
-				BB7DCF24D68837822F951E4E /* KWBeKindOfClassMatcher.h */,
-				55B98763EADB5D1DC0517869 /* KWBeKindOfClassMatcher.m */,
-				F7E71889CE8FC74C6051CC1F /* KWBeMemberOfClassMatcher.h */,
-				D546BE0F1FB90DF22AC1C82E /* KWBeMemberOfClassMatcher.m */,
-				B77F414322EC57E03D000540 /* KWBeSubclassOfClassMatcher.h */,
-				E3D4AC8A607F5E0322DF09FB /* KWBeSubclassOfClassMatcher.m */,
-				21B804FF6359C43EE980E650 /* KWBeTrueMatcher.h */,
-				34F6ECC50122BB8D15313895 /* KWBeTrueMatcher.m */,
-				FE5273F18E60934B8B3F7DA0 /* KWBeWithinMatcher.h */,
-				3870F7AEEFC88A90F5A7843F /* KWBeWithinMatcher.m */,
-				C31758A781FF3D2462845A17 /* KWBeZeroMatcher.h */,
-				B4787CCF45906E24C3527722 /* KWBeZeroMatcher.m */,
-				2EA291BF1BE9F258FBB14DD6 /* KWBeforeAllNode.h */,
-				7F889D9AD0ABD06A4C589495 /* KWBeforeAllNode.m */,
-				31930C210523BAC4C36DF829 /* KWBeforeEachNode.h */,
-				2CAEFCE0CAE766967FF57CCE /* KWBeforeEachNode.m */,
-				6058D3062A8DF333A4783C55 /* KWBlock.h */,
-				08CAC1432EACEAF9C7EC6598 /* KWBlock.m */,
-				B23F91B1034773CC84FD498A /* KWBlockNode.h */,
-				AB9F10D2B85AFB59BEDAFB9B /* KWBlockNode.m */,
-				F17E9250A54A1DEB562E8A70 /* KWBlockRaiseMatcher.h */,
-				6F2B5B228C98F5ED3B80A8A3 /* KWBlockRaiseMatcher.m */,
-				4FFD3A421ADEC11692C5FDA7 /* KWCallSite.h */,
-				A7EF4F7BB348E92EED8C8280 /* KWCallSite.m */,
-				2F52229D35D28DCA6AB72158 /* KWCaptureSpy.h */,
-				16F2D9EBD8FFF3D5438D6C98 /* KWCaptureSpy.m */,
-				A2AD2FECEE02F33E7D99682B /* KWChangeMatcher.h */,
-				6A82A07158552AAD01985F4E /* KWChangeMatcher.m */,
-				7F4CBD95A9689002F1ADFF5B /* KWConformToProtocolMatcher.h */,
-				0BAC523455A5CD50A0D5B29B /* KWConformToProtocolMatcher.m */,
-				65901D87F22DFA6CDF20D05C /* KWContainMatcher.h */,
-				EF290D9FE55F90B190D34E3B /* KWContainMatcher.m */,
-				C0C93AF33F7414590A8E1744 /* KWContainStringMatcher.h */,
-				22CC793150A8EF06060FA75D /* KWContainStringMatcher.m */,
-				CF12D98189040C5F6F39B5B8 /* KWContextNode.h */,
-				7C13729187073B91ADF5829F /* KWContextNode.m */,
-				FC97DD9187B314F2024D7310 /* KWCountType.h */,
-				CE9C128C1678730ABEC08982 /* KWDeviceInfo.h */,
-				253C84B24CB86C566DDB3CFC /* KWDeviceInfo.m */,
-				CCA546F8F3DE397A2CEC7F37 /* KWEqualMatcher.h */,
-				6A588CB962CE4B7C6A636689 /* KWEqualMatcher.m */,
-				54952A3904808E7911D2CF44 /* KWExample.h */,
-				DDE49CE00D1BF5DB70D6736B /* KWExample.m */,
-				E1847C045372449807F42421 /* KWExampleDelegate.h */,
-				EE0DFB53F0397C1DF256A780 /* KWExampleNode.h */,
-				01D809459B07EADC892EE1FE /* KWExampleNodeVisitor.h */,
-				EA633D4055285F175E4A0D17 /* KWExampleSuite.h */,
-				9E32BAC80A45B250427A6DF6 /* KWExampleSuite.m */,
-				EC351FCC3271E6CE21F92B3C /* KWExampleSuiteBuilder.h */,
-				7218F9CA3729532ED94FCDE1 /* KWExampleSuiteBuilder.m */,
-				B1785E19D8C6C1D8A8DD4C10 /* KWExistVerifier.h */,
-				F0BC7E121DBE7C0A31863772 /* KWExistVerifier.m */,
-				1D70C4E6E0D4654EF0E96309 /* KWExpectationType.h */,
-				957D4CCED793697634F0FE6C /* KWFailure.h */,
-				524DD8795EB32D3367891014 /* KWFailure.m */,
-				A7641E8FDF1729CCE6B7467F /* KWFormatter.h */,
-				0F6A0D801C8E6AF4B4842636 /* KWFormatter.m */,
-				DCDCF0CF41B32F57A41130EE /* KWFutureObject.h */,
-				E2F060FF644B5BAFB3BB1E19 /* KWFutureObject.m */,
-				679C1158B8BAAD952684864D /* KWGenericMatchEvaluator.h */,
-				E6BCEDBB89EC33D04924341C /* KWGenericMatchEvaluator.m */,
-				72FEF699AFF15DBBA4C41070 /* KWGenericMatcher.h */,
-				94D3D8BEE1C9B8758FFD82A1 /* KWGenericMatcher.m */,
-				B523B0A4E0B5598F0B83CA4A /* KWGenericMatchingAdditions.h */,
-				AD933846CC281937034B592A /* KWGenericMatchingAdditions.m */,
-				23A2F940EAADF93E81371E40 /* KWHaveMatcher.h */,
-				F42B202288760C1ED0022F88 /* KWHaveMatcher.m */,
-				A6033149BA898A01D7CCFB81 /* KWHaveValueMatcher.h */,
-				E7704007FEA95FD1AD5C3A94 /* KWHaveValueMatcher.m */,
-				76B41C8DF968F6BFDD3EA1C1 /* KWInequalityMatcher.h */,
-				F94E5915D04125DB58B0B4D3 /* KWInequalityMatcher.m */,
-				514F9A798C30A399277D1D3B /* KWIntercept.h */,
-				91AABE1CED27C64C4286E907 /* KWIntercept.m */,
-				6629E9E33001114CA0233C9A /* KWInvocationCapturer.h */,
-				2E90E538D7145B39D065ABF2 /* KWInvocationCapturer.m */,
-				6F41CED28A50A74D43C388E3 /* KWItNode.h */,
-				06BEC211E8353D3230D0118F /* KWItNode.m */,
-				C981976B39400360F0B01300 /* KWLet.h */,
-				1B475A6A05A55309B0F7EC7D /* KWLetNode.h */,
-				ACF773841CF5AE9A43C40A11 /* KWLetNode.m */,
-				42590BEF82B08D7CAF608BA5 /* KWMatchVerifier.h */,
-				5630292DF389227995A9073D /* KWMatchVerifier.m */,
-				DF6DA094E2C869C6044F563B /* KWMatcher.h */,
-				BF2F35DB5FD04A1F92CE3703 /* KWMatcher.m */,
-				4C79C8E6028D11DEA026CC7F /* KWMatcherFactory.h */,
-				A9E85D413300BA1CABFE332F /* KWMatcherFactory.m */,
-				8318D271FFFC2D8C807BF761 /* KWMatchers.h */,
-				73664B7D1F47F9B033E743AF /* KWMatchers.m */,
-				41B72D1C9AF5DE8F9674C438 /* KWMatching.h */,
-				D45CD445CA24EC3B1F961BE9 /* KWMessagePattern.h */,
-				2F438AB2D67392E51FC356C0 /* KWMessagePattern.m */,
-				C3F1C002D7BAFA5AC5DF4759 /* KWMessageSpying.h */,
-				642BAD7D8C7EAB8F673C6135 /* KWMessageTracker.h */,
-				35B4E4E6A0D37E4D4C2F6CB3 /* KWMessageTracker.m */,
-				CC896C8AD4820DB3566C91F6 /* KWMock.h */,
-				1B56B7287056FCCAA2F25B2F /* KWMock.m */,
-				629F12700A0778EB72709F29 /* KWNilMatcher.h */,
-				56C0C7987C8F8744D49ABBAD /* KWNilMatcher.m */,
-				64F68705367E685E4E6156CD /* KWNotificationMatcher.h */,
-				907B0F75545CE02D065D0A0A /* KWNotificationMatcher.m */,
-				5BBA2FA4976870BA76122515 /* KWNull.h */,
-				5FDF1FF4209B5612BD8BD21A /* KWNull.m */,
-				507903BDF700D2BCB157C2BE /* KWObjCUtilities.h */,
-				DC7CAC1595068A552CFA9C00 /* KWObjCUtilities.m */,
-				0AC2545C01C2D38918B3134F /* KWPendingNode.h */,
-				FD893CE9B36A0CB2D5BB0705 /* KWPendingNode.m */,
-				7651FB03E103BED64B9F65CA /* KWProbe.h */,
-				F7E0417F2C086086102C458C /* KWProbePoller.h */,
-				2B18D2EF337057F72769C5E9 /* KWProbePoller.m */,
-				833CF8BF2EE8EAF24EBEDB06 /* KWReceiveMatcher.h */,
-				EC23F87A1E1972BE10A42D7C /* KWReceiveMatcher.m */,
-				0D88BD24E3CB4EF42A100E63 /* KWRegisterMatchersNode.h */,
-				F64E9C695ED031D185C06578 /* KWRegisterMatchersNode.m */,
-				2E30C9D4AACB91267C2BD9B4 /* KWRegularExpressionPatternMatcher.h */,
-				C01DE0D96B4C5EA28A859B57 /* KWRegularExpressionPatternMatcher.m */,
-				1959B391BB85A87DBB5808E1 /* KWReporting.h */,
-				91929C2D58C5A8416135B3A9 /* KWRespondToSelectorMatcher.h */,
-				3CE228954A091185C7B66DD3 /* KWRespondToSelectorMatcher.m */,
-				97B0EA8F7C236D6E78477584 /* KWSpec.h */,
-				184016CFBC5E5B9083FE35E6 /* KWSpec.m */,
-				A14FF3CA9DD7D496A75DBD57 /* KWStringContainsMatcher.h */,
-				40446B3518C6451DA590B417 /* KWStringContainsMatcher.m */,
-				4628D4FB50A38945AD31B562 /* KWStringPrefixMatcher.h */,
-				90EEFEC5C1808D3309AEB101 /* KWStringPrefixMatcher.m */,
-				31AE1E9B659989B3DE90BBFF /* KWStringUtilities.h */,
-				56EC12DDEBCF3F4D479C186A /* KWStringUtilities.m */,
-				C8800830D40E0DB93DB55C6F /* KWStub.h */,
-				9D6CC4FE7A02C9544A0D972E /* KWStub.m */,
-				44F82ABA4EFB063310CAEB56 /* KWSuiteConfigurationBase.h */,
-				F315C29ED0107A0C2DA052AA /* KWSuiteConfigurationBase.m */,
-				E4517F0FEB205454DC86A3A0 /* KWSymbolicator.h */,
-				0C995D56AEAEED4FCECD748D /* KWSymbolicator.m */,
-				287266DB1819F9E456C3FC0D /* KWUserDefinedMatcher.h */,
-				1BA8719D40386993EDBC3C32 /* KWUserDefinedMatcher.m */,
-				FC2CB85DD5635F9E50FC17C7 /* KWValue.h */,
-				489AED0CA7A744874148C38F /* KWValue.m */,
-				0A439E08AA80A119515B78C7 /* KWVerifying.h */,
-				8E666D8CDFB2827BD290FD94 /* KWWorkarounds.h */,
-				67AFB1F55CB232E566BC3415 /* KWWorkarounds.m */,
-				503B283D7C48D72CB85B9B97 /* Kiwi.h */,
-				83BF94C1175D1827277213AC /* KiwiBlockMacros.h */,
-				EFA4FD58A097B9F2E875C31A /* KiwiConfiguration.h */,
-				D5CA701E1BCFC07E3492D623 /* KiwiMacros.h */,
-				B7CD89BD5058A4CB855232BF /* NSInvocation+KiwiAdditions.h */,
-				B379A30ABBAE39E5A9E3586F /* NSInvocation+KiwiAdditions.m */,
-				399D2ED2C85934046B6A4514 /* NSInvocation+OCMAdditions.h */,
-				1CC1E1865FB80ADFE9A30171 /* NSInvocation+OCMAdditions.m */,
-				A4E56118DD2D0E6A6082F715 /* NSMethodSignature+KiwiAdditions.h */,
-				5C3725F98245305A17A32366 /* NSMethodSignature+KiwiAdditions.m */,
-				32199018EA77754E2EB30C81 /* NSNumber+KiwiAdditions.h */,
-				D42F0DAED7DDCA342AB76E33 /* NSNumber+KiwiAdditions.m */,
-				5077A92DB8B6C8F61093497A /* NSObject+KiwiMockAdditions.h */,
-				A0BA6FF4233DAF5C8C29446F /* NSObject+KiwiMockAdditions.m */,
-				CC717C8EF29AA29ECFFBDCFB /* NSObject+KiwiSpyAdditions.h */,
-				A844C1450535C965AF7F7B35 /* NSObject+KiwiSpyAdditions.m */,
-				D73B3869B812FE56D84D1B6B /* NSObject+KiwiStubAdditions.h */,
-				80EDA518B365CA1EE37E0A72 /* NSObject+KiwiStubAdditions.m */,
-				93BC3110E2CA77C352E2F55F /* NSObject+KiwiVerifierAdditions.h */,
-				5D3D5832CB893C566BFABECE /* NSObject+KiwiVerifierAdditions.m */,
-				32411DCB52B723A95472F760 /* NSProxy+KiwiVerifierAdditions.h */,
-				B36EE767CA131A4A4CEB7AFB /* NSProxy+KiwiVerifierAdditions.m */,
-				AA58AC1AA206F2F88B8BA2B2 /* NSValue+KiwiAdditions.h */,
-				B52048C116FAE60E1A66EE03 /* NSValue+KiwiAdditions.m */,
-				5F0E034A9535F160FC2F16E4 /* Support Files */,
-			);
-			path = Kiwi;
-			sourceTree = "<group>";
-		};
-		77AD4157F0D75AE7E79D2B13 = {
-			isa = PBXGroup;
-			children = (
-				EAC6036D5810A768A474A930 /* Podfile */,
-				105C69EBA195A22C4E48F115 /* Frameworks */,
-				1E9A406B84CA4EE975D00F3E /* Pods */,
-				1DB5BE5E55305869B7F2AB2E /* Products */,
-				DFD30CC0DB6FD7FEFF3D23BB /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		9173E6654CC7EE840B5F3E1D /* Security */ = {
-			isa = PBXGroup;
-			children = (
-				50348AF571000FCEBD211904 /* AFSecurityPolicy.h */,
-				54599F64F8130FEA56ED3AAB /* AFSecurityPolicy.m */,
-			);
-			name = Security;
-			sourceTree = "<group>";
-		};
-		922A9F68A45245A773750107 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				EA60E0FEBD516D4841B15308 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig */,
-				E7AACA8EF1FADE1E604140BF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */,
-				022B28936154FE99F6751FF9 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */,
-				A438BDF462D96AB0A0CD8393 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch */,
+				5E07464270DE11E89C54B14A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.xcconfig */,
+				62C2A88DAADE5C3334920C2A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */,
+				52ECC1CB169F733F4FFD21C4 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m */,
+				6FBC78BD791745122AE2D0E9 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
 			sourceTree = "<group>";
 		};
-		9F5E60A50AF3B32E9969406B /* Reachability */ = {
+		27D0B057968008CEE75A5419 /* Mantle */ = {
 			isa = PBXGroup;
 			children = (
-				BE959059924AF347BB6E2C87 /* AFNetworkReachabilityManager.h */,
-				FBDDD2C0610ABC8BB87E7795 /* AFNetworkReachabilityManager.m */,
+				B275B49BD82B42FBB1AC384B /* MTLJSONAdapter.h */,
+				FBBD71D5F2DD9BA199F190F7 /* MTLJSONAdapter.m */,
+				0ACAE2CA1D731030F14985F4 /* MTLManagedObjectAdapter.h */,
+				8C0909B2DEB2A012C7D90EFE /* MTLManagedObjectAdapter.m */,
+				FA6DF0081E492323DE15D506 /* MTLModel.h */,
+				5DDBAFD254E5AD1C22F4B3B5 /* MTLModel.m */,
+				EECEAC192D4F7CFCBE45E6D8 /* MTLModel+NSCoding.h */,
+				983927CAAFCC097DA87D8147 /* MTLModel+NSCoding.m */,
+				2217CC03D3430D9508A8B50E /* MTLReflection.h */,
+				FCE4CAFB2A8AD604A2301A11 /* MTLReflection.m */,
+				83145D49F73F827A91190911 /* MTLValueTransformer.h */,
+				A34FFD6DE4AB76C387CC95CD /* MTLValueTransformer.m */,
+				A18399ECE4AFBFE094A610CA /* Mantle.h */,
+				B51820D96C5D0E156605C33C /* NSArray+MTLManipulationAdditions.h */,
+				527E19CCCBDEAEB120D2D375 /* NSArray+MTLManipulationAdditions.m */,
+				69DBFCE1E3C8DC198EBF4C70 /* NSDictionary+MTLManipulationAdditions.h */,
+				6F578B61DB81E4DA73EC94D7 /* NSDictionary+MTLManipulationAdditions.m */,
+				CFBCE7C2CB68A01857DD0A64 /* NSError+MTLModelException.h */,
+				1D26DAE34B95815CB3975075 /* NSError+MTLModelException.m */,
+				82267DB3CB3C73201A6665A9 /* NSObject+MTLComparisonAdditions.h */,
+				2B88B0754D37D90A3EB09B37 /* NSObject+MTLComparisonAdditions.m */,
+				FB27E0CAF2A6DB42D5C344FF /* NSValueTransformer+MTLInversionAdditions.h */,
+				ECFB003F2BAEFD9189A14C5F /* NSValueTransformer+MTLInversionAdditions.m */,
+				556248D7BF1D82E692C9FD09 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h */,
+				010EF7A76D170571A78B65F8 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m */,
+				317C2698D2FB4E99ACF96109 /* Support Files */,
+				AE0EBD61EFE6D3A89F47AFA4 /* extobjc */,
 			);
-			name = Reachability;
+			path = Mantle;
 			sourceTree = "<group>";
 		};
-		ABF9EEA94EB3308D118795DC /* iOS */ = {
+		2CFB386A783760B4C2EF1173 /* AFNetworking */ = {
 			isa = PBXGroup;
 			children = (
-				528718D50628D958123419A4 /* CoreGraphics.framework */,
-				17353691FAE342F2D70571D7 /* Foundation.framework */,
-				3AA477C0733A7F62246D92AE /* MobileCoreServices.framework */,
-				09792AC14685E9D04E440D77 /* Security.framework */,
-				92F9AF1CA7B0B78E330BB74C /* SystemConfiguration.framework */,
-				D79F1581656F9D57C860E43C /* XCTest.framework */,
+				8261FF9B09EA091684208DD8 /* AFNetworking.h */,
+				74B062B47313DDE591507B75 /* NSURLConnection */,
+				F8096436DF98BEC6753F7D7A /* NSURLSession */,
+				9901BC39C090F8072A763BFA /* Reachability */,
+				7939CEE79D9663DB903D52F0 /* Security */,
+				08C437091181E4DCCCDF1E4B /* Serialization */,
+				1C6097F0DE29AF308915F0A1 /* Support Files */,
+				B2ACC5EDFEF97F31DFF344B4 /* UIKit */,
 			);
-			name = iOS;
+			path = AFNetworking;
 			sourceTree = "<group>";
 		};
-		B02E7D170C46AED865EB951D /* UIKit */ = {
+		317C2698D2FB4E99ACF96109 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				99F9210D9297016A8B601EDC /* AFNetworkActivityIndicatorManager.h */,
-				C7B74DB16DEA2D85A82F5164 /* AFNetworkActivityIndicatorManager.m */,
-				8A6F11442FBAB1E548DC02BB /* UIActivityIndicatorView+AFNetworking.h */,
-				34BD9DE5DACB106274358294 /* UIActivityIndicatorView+AFNetworking.m */,
-				27A3B3749CA6F3E5BC0A7E4B /* UIAlertView+AFNetworking.h */,
-				9693AF1049729EEBA3694554 /* UIAlertView+AFNetworking.m */,
-				93BB90D4A4462E6971C6588B /* UIButton+AFNetworking.h */,
-				34AA9B9583960E51EB1596A8 /* UIButton+AFNetworking.m */,
-				FEE751FE63E66BFA79BC9BF6 /* UIImageView+AFNetworking.h */,
-				F520F38C42A187E464C87AEB /* UIImageView+AFNetworking.m */,
-				5AC2E0AC895237BF26C5D502 /* UIKit+AFNetworking.h */,
-				BD940068FC02B7E9843F1D43 /* UIProgressView+AFNetworking.h */,
-				F1D69FAB40D9AFB30395EC16 /* UIProgressView+AFNetworking.m */,
-				06E43F49A15467BD4BDD8D11 /* UIRefreshControl+AFNetworking.h */,
-				A81DDAB84DA0B4468EA806F3 /* UIRefreshControl+AFNetworking.m */,
-				339EB1AC3F31B193AC74A33D /* UIWebView+AFNetworking.h */,
-				02EBE93F5FBD04BF5E534711 /* UIWebView+AFNetworking.m */,
-			);
-			name = UIKit;
-			sourceTree = "<group>";
-		};
-		BBDC715335C9AEDB36F34F8F /* extobjc */ = {
-			isa = PBXGroup;
-			children = (
-				8482339B283BC309E62FC7FD /* EXTKeyPathCoding.h */,
-				814A8B1366DEDD64C4EF4B02 /* EXTRuntimeExtensions.h */,
-				8E02493ABB2EF8687A943186 /* EXTRuntimeExtensions.m */,
-				F831B34D33FF8BD23A15AFDB /* EXTScope.h */,
-				234C512D375240E8494F169F /* EXTScope.m */,
-				7B241C5797BF73CAD17DEE03 /* metamacros.h */,
-			);
-			name = extobjc;
-			sourceTree = "<group>";
-		};
-		C2E66DAD548BB5FA8A627DF2 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				6B211308C6CE641CA16A5234 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig */,
-				865802332036A75DEEED05AD /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */,
-				03A8689EE008D2033279A20F /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */,
-				541DDF273E86328788A60759 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
-			sourceTree = "<group>";
-		};
-		CC5E30576987414474A5802F /* NSURLSession */ = {
-			isa = PBXGroup;
-			children = (
-				7F970DBF5D742A6176FE8F81 /* AFHTTPSessionManager.h */,
-				622328EB72738488F729A0CC /* AFHTTPSessionManager.m */,
-				8618E224A86ACCDDC8D252F5 /* AFURLSessionManager.h */,
-				1611DC102473CCFCF15BDD60 /* AFURLSessionManager.m */,
-			);
-			name = NSURLSession;
-			sourceTree = "<group>";
-		};
-		CF8D314CD976BE28CAB2D6AE /* HNKServerFacade */ = {
-			isa = PBXGroup;
-			children = (
-				09CD708AB37C53F8AED75CE5 /* HNKServer.h */,
-				3704509641A36A2D62513BB8 /* HNKServer.m */,
-				200F3ADB42262CE3D6662BAD /* HNKServerFacade.h */,
-				922A9F68A45245A773750107 /* Support Files */,
-			);
-			path = HNKServerFacade;
-			sourceTree = "<group>";
-		};
-		D7E3345163A2BD3E28A9F801 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				D1C146F23388445B2E1CAA58 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig */,
-				E9DFA3A7B2F0FB5152135BBB /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */,
-				0211BCFAE34E1F9DB9A3CC67 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */,
-				CABE66DCCB1E4FF723B70935 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch */,
+				055E7CEDD00DFBBEB15AF336 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle.xcconfig */,
+				35ECB7026521B5F706F02C8F /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */,
+				6BB837219F4642C7538C4B31 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m */,
+				47DCF8E0D2E39A55AFDF9FF8 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
 			sourceTree = "<group>";
 		};
-		DFD30CC0DB6FD7FEFF3D23BB /* Targets Support Files */ = {
+		32177E465A34F0827D38DCFA /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				623FC0E2B90FA9ECD224FEE7 /* Pods-HNKGooglePlacesAutocomplete-Example */,
-				1E39826096790DF13D51A19E /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */,
+				4A9E7D4B36B502615088A1C5 /* Pods-HNKGooglePlacesAutocomplete-Example */,
+				3FF58B56B06ED6D498DFE181 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		FEE8D5EC6CE45CE33F47BA0B /* NSURLConnection */ = {
+		352717AEDA40E1F6FA14BDF6 /* HNKServerFacade */ = {
 			isa = PBXGroup;
 			children = (
-				DA8DFE431B39C713FEA278AF /* AFHTTPRequestOperation.h */,
-				D54940755402EBF0AB576D14 /* AFHTTPRequestOperation.m */,
-				081392ADF38F84C71A2393EF /* AFHTTPRequestOperationManager.h */,
-				1046E623ED4FE1E6EA3E951E /* AFHTTPRequestOperationManager.m */,
-				715586B0584683CA46DCFE9A /* AFURLConnectionOperation.h */,
-				89934EFF5ED5ACC58CA3990C /* AFURLConnectionOperation.m */,
+				BA5924D68145C49E5C943F8C /* HNKServer.h */,
+				E09E45B5C5CD1693D1E21AC9 /* HNKServer.m */,
+				22E78055A602629E8E4B3C2F /* HNKServerFacade.h */,
+				1F76060D038DCA3CBA054CE3 /* Support Files */,
+			);
+			path = HNKServerFacade;
+			sourceTree = "<group>";
+		};
+		3FF58B56B06ED6D498DFE181 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				B02627A56270D96908F77373 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.markdown */,
+				C2610752AC061C6B07B897CA /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-acknowledgements.plist */,
+				06641A7F1991A534516CFC29 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m */,
+				30504226DD5EE7261A3ACE8E /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-environment.h */,
+				86741A9B02D0B6489158FF14 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-resources.sh */,
+				1EB0717FF7CCD9B875B271BC /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */,
+				EEEEAE22321993C912C05D85 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
+			path = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests";
+			sourceTree = "<group>";
+		};
+		4A9E7D4B36B502615088A1C5 /* Pods-HNKGooglePlacesAutocomplete-Example */ = {
+			isa = PBXGroup;
+			children = (
+				EFAE34CC9D335DE772BDAA8B /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.markdown */,
+				84C3A374221D18C941907873 /* Pods-HNKGooglePlacesAutocomplete-Example-acknowledgements.plist */,
+				26616A12D74485DD7F35AFC3 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m */,
+				8F4C1C26EF3797C6DB1945A3 /* Pods-HNKGooglePlacesAutocomplete-Example-environment.h */,
+				FEB620D3654708659FE5CF5D /* Pods-HNKGooglePlacesAutocomplete-Example-resources.sh */,
+				70ED2D2CEDEA4D16924EA6BB /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */,
+				7DD1C8E0A676D4A26022970E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-Example";
+			path = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example";
+			sourceTree = "<group>";
+		};
+		4D1A7DF3E75C064CF13C242B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				9048A10A71BE7350762E5699 /* CoreGraphics.framework */,
+				00B21D11C3694710193BFFF4 /* Foundation.framework */,
+				B16E782834CDAA835A3AEE2A /* MobileCoreServices.framework */,
+				9D5C9C6007FD154C2964D3D2 /* Security.framework */,
+				0849B79997BC56E6E1F320CA /* SystemConfiguration.framework */,
+				0AB4D15FAD0279C2A6C3C934 /* XCTest.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		65E1D1E673909BA7CF61A568 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B0FB42ABA492CA445BA8D806 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.xcconfig */,
+				45CF2C549C5C7D4EA674CC93 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */,
+				BF5D10DF5C2F0ED786CDD31C /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m */,
+				FD9AF4CECF327CA8CA695C94 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
+			sourceTree = "<group>";
+		};
+		701D5462312D47D05ABA8F80 = {
+			isa = PBXGroup;
+			children = (
+				F97DFFB47534E266982015BE /* Podfile */,
+				C74BEBF6B3549D95DF79135D /* Frameworks */,
+				850AD3432928AF658EBC87CC /* Pods */,
+				8E73BABAF6B630D8FB139ABB /* Products */,
+				32177E465A34F0827D38DCFA /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		74B062B47313DDE591507B75 /* NSURLConnection */ = {
+			isa = PBXGroup;
+			children = (
+				681D36712B129F452C828D4F /* AFHTTPRequestOperation.h */,
+				ADACF9CDCD8D0F37A34CEEE4 /* AFHTTPRequestOperation.m */,
+				7E2AE3B9FB94EE7E53A3159F /* AFHTTPRequestOperationManager.h */,
+				0820F16F80DF639DAEF75CBC /* AFHTTPRequestOperationManager.m */,
+				979371E2DC3BCA3C1F8E9DC9 /* AFURLConnectionOperation.h */,
+				EAD947AD8E4E42CC4CD9CCAF /* AFURLConnectionOperation.m */,
 			);
 			name = NSURLConnection;
+			sourceTree = "<group>";
+		};
+		7939CEE79D9663DB903D52F0 /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				42F3358E6EDDD99BDA97257D /* AFSecurityPolicy.h */,
+				A1BA14C28082DEBAA8A2C0D3 /* AFSecurityPolicy.m */,
+			);
+			name = Security;
+			sourceTree = "<group>";
+		};
+		850AD3432928AF658EBC87CC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2CFB386A783760B4C2EF1173 /* AFNetworking */,
+				8DE8812AB862E26E494920BF /* HNKGooglePlacesAutocomplete */,
+				352717AEDA40E1F6FA14BDF6 /* HNKServerFacade */,
+				CE09E5076F0AD86101BFE955 /* Kiwi */,
+				27D0B057968008CEE75A5419 /* Mantle */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		8DE8812AB862E26E494920BF /* HNKGooglePlacesAutocomplete */ = {
+			isa = PBXGroup;
+			children = (
+				B93B3747BF28C0DC7F495048 /* CLPlacemark+HNKAdditions.h */,
+				BE1BF96547435A8130BC87F3 /* CLPlacemark+HNKAdditions.m */,
+				1B8FDEEB3D678AAEFBB7B5EE /* HNKGooglePlacesAutocomplete.h */,
+				A179B3EE45FB59AADBA02D32 /* Models */,
+				96F58896CDB7FAF06EBE7D60 /* Support Files */,
+			);
+			path = HNKGooglePlacesAutocomplete;
+			sourceTree = "<group>";
+		};
+		8E73BABAF6B630D8FB139ABB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F1E2D7F256FB4DE806130029 /* libPods-HNKGooglePlacesAutocomplete-Example.a */,
+				631F4A85166DA19B140AAF06 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */,
+				D252F0F6E6E6678CA1E5D9D3 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */,
+				0A7A873270F44E276387B15A /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */,
+				39320D3F8464D4AD985D1A6A /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */,
+				5F78D1C482590761967E5705 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */,
+				A8269E21D05170FF6B63BB4A /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		96F58896CDB7FAF06EBE7D60 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				FE2DFC6A8F7A0336FD47E80B /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.xcconfig */,
+				2DEF0B9E43511051CFDA9351 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */,
+				2B0E839C7378C0738E9E3BC6 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m */,
+				0C432A4558C1D7D51BE399B3 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
+			sourceTree = "<group>";
+		};
+		9901BC39C090F8072A763BFA /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				FD70C4363BD69C147DCB7C19 /* AFNetworkReachabilityManager.h */,
+				B4B0F593C56E23FB94DA5595 /* AFNetworkReachabilityManager.m */,
+			);
+			name = Reachability;
+			sourceTree = "<group>";
+		};
+		9E8A9A262CDA9759FB3A14B8 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				5AF59C17EC4BA068CDDC0EE6 /* HNKGooglePlacesServer.h */,
+				40793574779A3C35386709EB /* HNKGooglePlacesServer.m */,
+			);
+			name = Networking;
+			sourceTree = "<group>";
+		};
+		A179B3EE45FB59AADBA02D32 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5BBD3815CF09824050FAD0F3 /* HNKGooglePlacesAutocompleteModel.h */,
+				3212FD172EC8CC8484E012F2 /* HNKGooglePlacesAutocompleteModel.m */,
+				233FEC86EFB6F219E93105A7 /* HNKGooglePlacesAutocompletePlace.h */,
+				E4545C08DE9A561A278D8197 /* HNKGooglePlacesAutocompletePlace.m */,
+				F4F1A003FBAE439D59C5416B /* HNKGooglePlacesAutocompletePlaceSubstring.h */,
+				61C1663E2160FAA98037DE6A /* HNKGooglePlacesAutocompletePlaceSubstring.m */,
+				227F1CA02855AA44E3F2CA53 /* HNKGooglePlacesAutocompletePlaceTerm.h */,
+				A2539A48472FC403B1233EEA /* HNKGooglePlacesAutocompletePlaceTerm.m */,
+				010243B947001D659539D13C /* HNKGooglePlacesAutocompleteQuery.h */,
+				D20A6E820FE0F89BCCD20879 /* HNKGooglePlacesAutocompleteQuery.m */,
+				CDE90FCDE593FB3F346B9EF2 /* HNKGooglePlacesAutocompleteQueryConfig.h */,
+				D0354A1F8D5A2E496BF1F3CE /* HNKGooglePlacesAutocompleteQueryConfig.m */,
+				FCD71CD7B5300FD2ADFE8A2A /* HNKGooglePlacesAutocompleteQueryResponse.h */,
+				5A04A85A4AF45E09211D05F7 /* HNKGooglePlacesAutocompleteQueryResponse.m */,
+				9E8A9A262CDA9759FB3A14B8 /* Networking */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		AE0EBD61EFE6D3A89F47AFA4 /* extobjc */ = {
+			isa = PBXGroup;
+			children = (
+				885E4D24A736984173D49371 /* EXTKeyPathCoding.h */,
+				1600E36AE9638A28927580CA /* EXTRuntimeExtensions.h */,
+				93747B5D2398EB141394C75C /* EXTRuntimeExtensions.m */,
+				3FB7CB2E54BF7556D6507620 /* EXTScope.h */,
+				AD657064F8AF2E5C24290147 /* EXTScope.m */,
+				EA061D9CAE43EE7F7CCE08A7 /* metamacros.h */,
+			);
+			name = extobjc;
+			sourceTree = "<group>";
+		};
+		B2ACC5EDFEF97F31DFF344B4 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				40EAB20C2A9D2282510B5C57 /* AFNetworkActivityIndicatorManager.h */,
+				2EFB6B59B47D52A12A40191A /* AFNetworkActivityIndicatorManager.m */,
+				79451FB8991C23B35C99512A /* UIActivityIndicatorView+AFNetworking.h */,
+				7141F71B45711513E9CDC94C /* UIActivityIndicatorView+AFNetworking.m */,
+				3CC29ACC246DA6F7E1F67EFC /* UIAlertView+AFNetworking.h */,
+				5FAAAC985E41A4C51982669F /* UIAlertView+AFNetworking.m */,
+				49EF17E0F1C2B8E07C24A8AE /* UIButton+AFNetworking.h */,
+				25926D5CE0A7337B84AAD14B /* UIButton+AFNetworking.m */,
+				7D6D2BA4436C9C225AE57149 /* UIImageView+AFNetworking.h */,
+				BF3B00A9B5261E8F00DCAD73 /* UIImageView+AFNetworking.m */,
+				57953201D1E6F7E1007483B5 /* UIKit+AFNetworking.h */,
+				3EDBB25B482BC397819DA2B6 /* UIProgressView+AFNetworking.h */,
+				E473DF1FB362FD896BAAD5F7 /* UIProgressView+AFNetworking.m */,
+				552DBDE7DCDDC365C46EE3CC /* UIRefreshControl+AFNetworking.h */,
+				CEDAB7C76B23C7810E2BB464 /* UIRefreshControl+AFNetworking.m */,
+				8F9CFA70131BE2D3F63FFD61 /* UIWebView+AFNetworking.h */,
+				D8ED5C06FB8AA26D350BF759 /* UIWebView+AFNetworking.m */,
+			);
+			name = UIKit;
+			sourceTree = "<group>";
+		};
+		C74BEBF6B3549D95DF79135D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4D1A7DF3E75C064CF13C242B /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CE09E5076F0AD86101BFE955 /* Kiwi */ = {
+			isa = PBXGroup;
+			children = (
+				C725026B8D6C6812560B24FE /* KWAfterAllNode.h */,
+				BD4153A19B0C1B9B18C9C291 /* KWAfterAllNode.m */,
+				0AD2DCFCB40D91C3836479BE /* KWAfterEachNode.h */,
+				B29016C0A3DFEA6B205E6EAD /* KWAfterEachNode.m */,
+				9B936D8CB942A5A56CD2976A /* KWAllTestsSuite.m */,
+				648E7639AF9E1840296F29D8 /* KWAny.h */,
+				85440B27C3A6125225C6C922 /* KWAny.m */,
+				73EB38A2BAC393BD701C1DEC /* KWAsyncVerifier.h */,
+				832416BFE0EAE3B092938115 /* KWAsyncVerifier.m */,
+				EB9D5E32969C075AF7602E44 /* KWBeBetweenMatcher.h */,
+				25491BAADBFD661DD7CBA8CF /* KWBeBetweenMatcher.m */,
+				C5129A5942AD017A33AC8426 /* KWBeEmptyMatcher.h */,
+				F4F3F6D856E0B9DC7101F9C6 /* KWBeEmptyMatcher.m */,
+				ABB8D740959AD367214CCB1C /* KWBeIdenticalToMatcher.h */,
+				721B7DF2174B45CD235D4BDC /* KWBeIdenticalToMatcher.m */,
+				FFF2F31246B4580FF518BA05 /* KWBeKindOfClassMatcher.h */,
+				68C09A24E35AB2ADAF91B5AA /* KWBeKindOfClassMatcher.m */,
+				7A53DAAAF8D2724A47AE6831 /* KWBeMemberOfClassMatcher.h */,
+				5C09740098CB0ED04CF0EF8D /* KWBeMemberOfClassMatcher.m */,
+				81D01AC5EC422EFF65314554 /* KWBeSubclassOfClassMatcher.h */,
+				B97D087AB1CBFC2AE12B6E8A /* KWBeSubclassOfClassMatcher.m */,
+				AE01E1A98E0603E4F08E369B /* KWBeTrueMatcher.h */,
+				AF2F31E6BF07EA57DAF28CCB /* KWBeTrueMatcher.m */,
+				1052FAC22AA67AF2EC36D7E2 /* KWBeWithinMatcher.h */,
+				E5F823084A1FBC33E9F0872C /* KWBeWithinMatcher.m */,
+				09F2B9ACCA75884893CEB73C /* KWBeZeroMatcher.h */,
+				8689A6EB65C152EC31D9351B /* KWBeZeroMatcher.m */,
+				6714CE962A2745BAA0576AEF /* KWBeforeAllNode.h */,
+				FEB132241245662CB0C76262 /* KWBeforeAllNode.m */,
+				76201B007C317EF01040913A /* KWBeforeEachNode.h */,
+				DA65AEE5BCAE9E492256C16C /* KWBeforeEachNode.m */,
+				0BEB31C64F8A1853B465370C /* KWBlock.h */,
+				C246BD0BDD2017BFFE742136 /* KWBlock.m */,
+				87FE19C4EF4405A7CA75D53D /* KWBlockNode.h */,
+				D1B81239511CEE949C339D0C /* KWBlockNode.m */,
+				10D0B97615587ECBE1931B49 /* KWBlockRaiseMatcher.h */,
+				0DE08483D913F364A4B88314 /* KWBlockRaiseMatcher.m */,
+				1AE8ECEF2A2E1B6EBCF26FBA /* KWCallSite.h */,
+				2B033E63CE53E620F14B1722 /* KWCallSite.m */,
+				9C6885FE1918B1D5FCCB5BD3 /* KWCaptureSpy.h */,
+				722133A952407EED89644AFA /* KWCaptureSpy.m */,
+				292F2E33DDFAE0DC4004FC29 /* KWChangeMatcher.h */,
+				37E14587827A8C3CC6C35538 /* KWChangeMatcher.m */,
+				549CC6A6E90DC4DB5E187E3F /* KWConformToProtocolMatcher.h */,
+				8BA5EA7F6390A5FD58B503C1 /* KWConformToProtocolMatcher.m */,
+				C87B40101D918DBE3560083F /* KWContainMatcher.h */,
+				C4EB6F8BD01AFDDC98B7B60D /* KWContainMatcher.m */,
+				72B7B71AE14FD98605BA7FD1 /* KWContainStringMatcher.h */,
+				B72F8CC36CF3EF7BF883CD71 /* KWContainStringMatcher.m */,
+				9A3381FFD966F8078306796A /* KWContextNode.h */,
+				0362F1E849DC4875CFF89286 /* KWContextNode.m */,
+				3A5E9DEB1501BABA40C65EA6 /* KWCountType.h */,
+				44218131D89E3B1FC9D5A09B /* KWDeviceInfo.h */,
+				EF1EF0A919CA66089DEFCE42 /* KWDeviceInfo.m */,
+				105D446E4751C4E31439EE7A /* KWEqualMatcher.h */,
+				355DEDFA5869A2C4E5BE70E2 /* KWEqualMatcher.m */,
+				C5ECF20F98365807824D5A80 /* KWExample.h */,
+				C51E500A571D652D9BB558CC /* KWExample.m */,
+				B1430EC7B7A6822CEE24DA53 /* KWExampleDelegate.h */,
+				733E69147B12A91C3D2F7469 /* KWExampleNode.h */,
+				AB274ADFC1EDD20DFCE0EB4E /* KWExampleNodeVisitor.h */,
+				9E2CDA446D629F7EAB891CCB /* KWExampleSuite.h */,
+				EE678E462836A712323417D0 /* KWExampleSuite.m */,
+				00E6BEBF7C1394A81B96155B /* KWExampleSuiteBuilder.h */,
+				76ABD82BC4AEB8CA257C99AD /* KWExampleSuiteBuilder.m */,
+				C907D7980FC98B5B5B565692 /* KWExistVerifier.h */,
+				C70A82B07335BBE631FC70DA /* KWExistVerifier.m */,
+				55F2D768E9521D4DAD42E11A /* KWExpectationType.h */,
+				E706A16A7639546A99250947 /* KWFailure.h */,
+				5FC592DD80FFBEB0494961E8 /* KWFailure.m */,
+				082B0A7B4F1A3D04E393E7A0 /* KWFormatter.h */,
+				F57C5A7D2D81698AB8BC3015 /* KWFormatter.m */,
+				59E45A735D023A120B193A4D /* KWFutureObject.h */,
+				228B9B1BEBC410181B0E354D /* KWFutureObject.m */,
+				C8224EBBC7A835A7DA27BE73 /* KWGenericMatchEvaluator.h */,
+				500A16F2ABC6DC83680E6D2B /* KWGenericMatchEvaluator.m */,
+				9B3971D7A328368B1EFDABA2 /* KWGenericMatcher.h */,
+				3B56A5DBD79C00A37FBF1674 /* KWGenericMatcher.m */,
+				7BB55FEA6D2072567D92439A /* KWGenericMatchingAdditions.h */,
+				9BD1FCEAA03B2F2473C5E869 /* KWGenericMatchingAdditions.m */,
+				CE5F9399F060572F99866945 /* KWHaveMatcher.h */,
+				3FE37FBCA3F0F2B03324323A /* KWHaveMatcher.m */,
+				BD3B5C6C5E858E10AD8375E7 /* KWHaveValueMatcher.h */,
+				20DAC95D224EAFE70DB75ADC /* KWHaveValueMatcher.m */,
+				A4F915DB034209E392AA4CA3 /* KWInequalityMatcher.h */,
+				B5A7D5BBC2D95B105E40727D /* KWInequalityMatcher.m */,
+				6783109AFC231C57654FDCDD /* KWIntercept.h */,
+				C68045EBC5A99E5C108F24C6 /* KWIntercept.m */,
+				6310F6675AF4AD7BE7692B6C /* KWInvocationCapturer.h */,
+				A426309C2869CC9FAC706FFF /* KWInvocationCapturer.m */,
+				7E40F098BD92D7DFDD394295 /* KWItNode.h */,
+				5A72E3B0CDBD39D96F700573 /* KWItNode.m */,
+				CCF4D2B2B1B0793E2F40EF87 /* KWLet.h */,
+				40A66751315DFD2CF46319DB /* KWLetNode.h */,
+				23B097853E62D4101D8829C5 /* KWLetNode.m */,
+				C026BB0B0824CF270DF25F05 /* KWMatchVerifier.h */,
+				00C1E48997104B8A0CE661DE /* KWMatchVerifier.m */,
+				42E473123FE91DED9D3D1D80 /* KWMatcher.h */,
+				31582A72A256A5F5579C40BC /* KWMatcher.m */,
+				07BEBE406BA569F669FF4460 /* KWMatcherFactory.h */,
+				979AA37F4938B3003CE4D352 /* KWMatcherFactory.m */,
+				7202A4CC5371FC608B616698 /* KWMatchers.h */,
+				4107BE41A34681EEC76F2005 /* KWMatchers.m */,
+				4137EDD51DDC99D208F718F9 /* KWMatching.h */,
+				7427F066E7CC974C9AA63BEE /* KWMessagePattern.h */,
+				C3E738B32D1B7A76E18A36D2 /* KWMessagePattern.m */,
+				281BA20036AA57DBA9A1AF9C /* KWMessageSpying.h */,
+				08824E825A6719898C23256D /* KWMessageTracker.h */,
+				F82CE9C50DE2EB5D6275BFF3 /* KWMessageTracker.m */,
+				7155218DCB2550B1CEE2AB69 /* KWMock.h */,
+				6875F04EABC52730FF7ED0B7 /* KWMock.m */,
+				609459F56B11A147E435C7BC /* KWNilMatcher.h */,
+				37318A03ABD30BF24418AC75 /* KWNilMatcher.m */,
+				4422846B47EAB643E3520E1C /* KWNotificationMatcher.h */,
+				A26E260C9799159DA7092A33 /* KWNotificationMatcher.m */,
+				E1F0E450100A8B8451D13A32 /* KWNull.h */,
+				642C5B37B895F37327898670 /* KWNull.m */,
+				2F49B6A6512CEDDBB5F3B139 /* KWObjCUtilities.h */,
+				DE28C0DC91CDAC07DE709042 /* KWObjCUtilities.m */,
+				672941BAEBA7C288214F67CB /* KWPendingNode.h */,
+				79AC4F574E1DE55327C639F1 /* KWPendingNode.m */,
+				40150474A41CDBE269D53516 /* KWProbe.h */,
+				F695E5FD177B4B9EDDD99322 /* KWProbePoller.h */,
+				30D6991BB531EED14CE12034 /* KWProbePoller.m */,
+				4181F501C93565E53918C60E /* KWReceiveMatcher.h */,
+				B0D49FF0C2E69758A6F0A435 /* KWReceiveMatcher.m */,
+				255B6246724D372E0C784913 /* KWRegisterMatchersNode.h */,
+				4C9BEC7E78E2C7E6ED7C8B56 /* KWRegisterMatchersNode.m */,
+				9214CD0A612664E006226CD3 /* KWRegularExpressionPatternMatcher.h */,
+				B0C87521FCE58537C2E0EE76 /* KWRegularExpressionPatternMatcher.m */,
+				D432B5A3263BFD43852C7632 /* KWReporting.h */,
+				95C0A2C1AB05CFFB7DC47385 /* KWRespondToSelectorMatcher.h */,
+				F4787184CE58BDEA445AADAD /* KWRespondToSelectorMatcher.m */,
+				5DF178E8FF4ACE4BCE67088D /* KWSpec.h */,
+				7D39E3712995787F8D1F82DB /* KWSpec.m */,
+				0E6CE5E5C0DF10ABD47EE09F /* KWStringContainsMatcher.h */,
+				08A19783740EEB46F94713DB /* KWStringContainsMatcher.m */,
+				10EDB71B91B02F2A1BD684D0 /* KWStringPrefixMatcher.h */,
+				E748C07296161769F7B1F78C /* KWStringPrefixMatcher.m */,
+				ABBA83830116B5FB194FAA1E /* KWStringUtilities.h */,
+				FB0918F41F27FEA1BCFF783F /* KWStringUtilities.m */,
+				B10DFB26BF441674BF454A31 /* KWStub.h */,
+				D56A58B71A5EACA5D252F3B2 /* KWStub.m */,
+				88ACEE277F8D5693394E79D0 /* KWSuiteConfigurationBase.h */,
+				4FF7DD1383EB27EE2167A32F /* KWSuiteConfigurationBase.m */,
+				E2C44ED22FBB9178AAA07397 /* KWSymbolicator.h */,
+				8C5242FE5C1098CB27DC77CA /* KWSymbolicator.m */,
+				7143620875F27942A27163AC /* KWUserDefinedMatcher.h */,
+				8B715902432199163C644C9C /* KWUserDefinedMatcher.m */,
+				4934A9E5653138F02A72E15F /* KWValue.h */,
+				0A685B442042426996D1B790 /* KWValue.m */,
+				E685C07400862F0C43753B6F /* KWVerifying.h */,
+				D1ADE9D07A80471786246DAA /* KWWorkarounds.h */,
+				87FD7A0C64A9B19CC92DE663 /* KWWorkarounds.m */,
+				3A7D0076E69942EF861C830B /* Kiwi.h */,
+				5547E8946415BCFF2687C3FB /* KiwiBlockMacros.h */,
+				BFB415FBCBBCD15E98C25BA2 /* KiwiConfiguration.h */,
+				B7018060801AB9C046436C71 /* KiwiMacros.h */,
+				2EB13C6A3EC95EC04FB86C0F /* NSInvocation+KiwiAdditions.h */,
+				C30D1A79D9BD7E9E7B11F72E /* NSInvocation+KiwiAdditions.m */,
+				8AF39182295F17216598BB7A /* NSInvocation+OCMAdditions.h */,
+				4CD929DAC6F4C02089D2660D /* NSInvocation+OCMAdditions.m */,
+				F844BBF4F25054BEC88197CA /* NSMethodSignature+KiwiAdditions.h */,
+				2581A7786B7C24654918E1CD /* NSMethodSignature+KiwiAdditions.m */,
+				3AA082184C08EE4AC2B11DB1 /* NSNumber+KiwiAdditions.h */,
+				4841DA8221B6D68DA8732C2C /* NSNumber+KiwiAdditions.m */,
+				85C7ED0C4428EF79DDFA27D2 /* NSObject+KiwiMockAdditions.h */,
+				6B1AA6A5F002A393C1173972 /* NSObject+KiwiMockAdditions.m */,
+				C6AACF1C5AF6C2F26A88ADF9 /* NSObject+KiwiSpyAdditions.h */,
+				C6179FCBD8AEEA8636E75610 /* NSObject+KiwiSpyAdditions.m */,
+				412A1CE6E03657223EC2364C /* NSObject+KiwiStubAdditions.h */,
+				F143E90D486F63985C039631 /* NSObject+KiwiStubAdditions.m */,
+				F2EC69AA85ADAAB1B04F70D8 /* NSObject+KiwiVerifierAdditions.h */,
+				91D4FE8D1A36492839D2FA40 /* NSObject+KiwiVerifierAdditions.m */,
+				EC74E98383875E4506A5AD02 /* NSProxy+KiwiVerifierAdditions.h */,
+				9F19D47C11FB1B1D3A48D833 /* NSProxy+KiwiVerifierAdditions.m */,
+				F112277E31042594585ED74D /* NSValue+KiwiAdditions.h */,
+				D6A97C20A6FA8F514F98C226 /* NSValue+KiwiAdditions.m */,
+				65E1D1E673909BA7CF61A568 /* Support Files */,
+			);
+			path = Kiwi;
+			sourceTree = "<group>";
+		};
+		F8096436DF98BEC6753F7D7A /* NSURLSession */ = {
+			isa = PBXGroup;
+			children = (
+				3CE46019B390E97F8DF7EA63 /* AFHTTPSessionManager.h */,
+				F9AA4351CF37E9A005EA9238 /* AFHTTPSessionManager.m */,
+				C15F918C2E0C6885A74307EB /* AFURLSessionManager.h */,
+				66DEAEF269DC1D1A4F91E3D5 /* AFURLSessionManager.m */,
+			);
+			name = NSURLSession;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		066626A993809813953C9B97 /* Headers */ = {
+		3112A3A48B76313F93E2007E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				652311A688772C7371528AFF /* HNKServer.h in Headers */,
-				368031F0239CB95A5588FC1C /* HNKServerFacade.h in Headers */,
+				1E8D413AAD063F53D6F9B2F7 /* KWAfterAllNode.h in Headers */,
+				5485BA8E48EFD8C73D43291E /* KWAfterEachNode.h in Headers */,
+				30D6A129D964A3EDE7F6A289 /* KWAny.h in Headers */,
+				59987A829FC4320EC7204828 /* KWAsyncVerifier.h in Headers */,
+				CC64466EE76A3D0EB2FEB842 /* KWBeBetweenMatcher.h in Headers */,
+				7B61433755A852218DA7C5D5 /* KWBeEmptyMatcher.h in Headers */,
+				A7489A082F354F2DC2EFF128 /* KWBeIdenticalToMatcher.h in Headers */,
+				725C9FC15BB81AAAEB55D9DE /* KWBeKindOfClassMatcher.h in Headers */,
+				808C0405D476412614B0347B /* KWBeMemberOfClassMatcher.h in Headers */,
+				E2B250701DB2C10F82264A9D /* KWBeSubclassOfClassMatcher.h in Headers */,
+				665EA7DC315F36D9C8509D30 /* KWBeTrueMatcher.h in Headers */,
+				DFE94C593973476C4537E887 /* KWBeWithinMatcher.h in Headers */,
+				1B914C8C74DF2BC525D5DB9D /* KWBeZeroMatcher.h in Headers */,
+				0D36DBACBAD34C969F696D60 /* KWBeforeAllNode.h in Headers */,
+				EF97163AA02728C65E16B8D0 /* KWBeforeEachNode.h in Headers */,
+				488CAF2E025369675740F27F /* KWBlock.h in Headers */,
+				F868BA664B5EC8A5D743BBEC /* KWBlockNode.h in Headers */,
+				DF62D9815043F7157E803A76 /* KWBlockRaiseMatcher.h in Headers */,
+				CC52B85A7FF9E61E59D41B44 /* KWCallSite.h in Headers */,
+				073956915AC0595235BC4266 /* KWCaptureSpy.h in Headers */,
+				C9FBF78154097D459605C0BD /* KWChangeMatcher.h in Headers */,
+				38AA04A9DA60C15473D7E074 /* KWConformToProtocolMatcher.h in Headers */,
+				5B183FE2CB6F0683DDC29C94 /* KWContainMatcher.h in Headers */,
+				0E48FE9B008510DF9E21EF65 /* KWContainStringMatcher.h in Headers */,
+				C813EF9514EA80AB339A2DB9 /* KWContextNode.h in Headers */,
+				A3F0B960106564FAE41640BA /* KWCountType.h in Headers */,
+				28C95AFDA5B04B5A12CD7190 /* KWDeviceInfo.h in Headers */,
+				F847DC3FA76CF48FE6FA466F /* KWEqualMatcher.h in Headers */,
+				4CB6B8266BD716707F46DF0E /* KWExample.h in Headers */,
+				6546F235364886D7B30252D8 /* KWExampleDelegate.h in Headers */,
+				06D2AED64FCA70C6C179DF8F /* KWExampleNode.h in Headers */,
+				9971C33D28B361E705578BB9 /* KWExampleNodeVisitor.h in Headers */,
+				3E85337DA99609CB01E66E67 /* KWExampleSuite.h in Headers */,
+				74DA91965AD93C82DD3E5B86 /* KWExampleSuiteBuilder.h in Headers */,
+				F5D7CBACA9FD102DFCF28A0A /* KWExistVerifier.h in Headers */,
+				0CA98271D5849DC0353C406E /* KWExpectationType.h in Headers */,
+				486C35649D01DC21FE6461FD /* KWFailure.h in Headers */,
+				15CE7F215A47F66CFEBBBD27 /* KWFormatter.h in Headers */,
+				DDA0EE9454AD57448BA1ACC8 /* KWFutureObject.h in Headers */,
+				A66A52843FEB94DF3FF111F5 /* KWGenericMatchEvaluator.h in Headers */,
+				DA137EC3CEFEAA3274E5BBA8 /* KWGenericMatcher.h in Headers */,
+				5B031095627440B91F521735 /* KWGenericMatchingAdditions.h in Headers */,
+				5EC697980ABFE9EE8032569F /* KWHaveMatcher.h in Headers */,
+				5D5C7E0B666DAFDD5F003696 /* KWHaveValueMatcher.h in Headers */,
+				A02023D2D3A8ED91CC2BBDD2 /* KWInequalityMatcher.h in Headers */,
+				AC56EFDC0BBD3DB70DC4EA3A /* KWIntercept.h in Headers */,
+				974350FFF8BE6FB696E78D6F /* KWInvocationCapturer.h in Headers */,
+				47E32C9B97A8BFAB24EE6CF6 /* KWItNode.h in Headers */,
+				B15A7F08FA5DF19C9E604F22 /* KWLet.h in Headers */,
+				7890E306FBDF1A2C51859F79 /* KWLetNode.h in Headers */,
+				BDE70EEF3A2811B579D8994D /* KWMatchVerifier.h in Headers */,
+				693BCBFCC8658C1235381BA9 /* KWMatcher.h in Headers */,
+				37BF703C73AF9DE8C5B33277 /* KWMatcherFactory.h in Headers */,
+				4BE954BDC38E7331AB13075E /* KWMatchers.h in Headers */,
+				E4EBF0E5FA2B9C5D6164D4D0 /* KWMatching.h in Headers */,
+				973EDBD1FCD780DF1BEC2594 /* KWMessagePattern.h in Headers */,
+				80A7F0B003732504E7C21E7D /* KWMessageSpying.h in Headers */,
+				FAC6F95A0713ABF4B1830844 /* KWMessageTracker.h in Headers */,
+				1B0707D48BD79CA5673A938F /* KWMock.h in Headers */,
+				A558FC612C95B04B65B0C150 /* KWNilMatcher.h in Headers */,
+				DABA649E4F58AC99F5F505D4 /* KWNotificationMatcher.h in Headers */,
+				933B240DCF52DC58D00565C2 /* KWNull.h in Headers */,
+				7B050014EF9100C37D14F762 /* KWObjCUtilities.h in Headers */,
+				51A54A38E3624C07EAB91B55 /* KWPendingNode.h in Headers */,
+				7594816461EDE4A525DFCC4A /* KWProbe.h in Headers */,
+				8BF9CD35E6B1FFE10EDD308C /* KWProbePoller.h in Headers */,
+				FC405EC038C374680BBC867F /* KWReceiveMatcher.h in Headers */,
+				ED4CF39BA34F30831443EDEA /* KWRegisterMatchersNode.h in Headers */,
+				88ED6D75A0DE9A49115A7959 /* KWRegularExpressionPatternMatcher.h in Headers */,
+				E8C55E5D02B22F96EBA612F3 /* KWReporting.h in Headers */,
+				B90776CB2E58193243562A39 /* KWRespondToSelectorMatcher.h in Headers */,
+				4DC50975B6C9A568A0534703 /* KWSpec.h in Headers */,
+				88BA31B394D17E91E8217E46 /* KWStringContainsMatcher.h in Headers */,
+				50B174B430925F4C32E60510 /* KWStringPrefixMatcher.h in Headers */,
+				5BA134667CAC4C49845113A2 /* KWStringUtilities.h in Headers */,
+				0E33B20300E8C3B3B4F05C30 /* KWStub.h in Headers */,
+				731682C1EE1A65FBA3FE6B44 /* KWSuiteConfigurationBase.h in Headers */,
+				3787D9988D7F8B5C496A10D8 /* KWSymbolicator.h in Headers */,
+				33F95ECDCB179210203FB4B1 /* KWUserDefinedMatcher.h in Headers */,
+				E1197D91C6A0CAC999AC43BF /* KWValue.h in Headers */,
+				4B61203AD99ED5060417ACCD /* KWVerifying.h in Headers */,
+				DD53596BB31F0785727A76E9 /* KWWorkarounds.h in Headers */,
+				57DFE5B12128BAC63FE399EF /* Kiwi.h in Headers */,
+				0AF97B2AFC936256D71F8583 /* KiwiBlockMacros.h in Headers */,
+				CCC1C6958039D56D8F5A1591 /* KiwiConfiguration.h in Headers */,
+				7DB716FC793688E73FDA6078 /* KiwiMacros.h in Headers */,
+				D277EBCB4E8066C46D9525D6 /* NSInvocation+KiwiAdditions.h in Headers */,
+				7EA00273D66A544C91B3D7C6 /* NSInvocation+OCMAdditions.h in Headers */,
+				CCD6D77154C416393D67112F /* NSMethodSignature+KiwiAdditions.h in Headers */,
+				552D9A52A254F2B2DE86DEC6 /* NSNumber+KiwiAdditions.h in Headers */,
+				09DEA89E36F92D4B80188420 /* NSObject+KiwiMockAdditions.h in Headers */,
+				5F4D2852ECBB70FE29196013 /* NSObject+KiwiSpyAdditions.h in Headers */,
+				38E5B050956993BDB3C3C0A5 /* NSObject+KiwiStubAdditions.h in Headers */,
+				F135DBC98A27E9FBCCF7F036 /* NSObject+KiwiVerifierAdditions.h in Headers */,
+				345BAF9A011202868BA5AD9E /* NSProxy+KiwiVerifierAdditions.h in Headers */,
+				7B2CA14C9A7C892170FB1A43 /* NSValue+KiwiAdditions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		15074D013C76834B4E9817B2 /* Headers */ = {
+		7E59897E45CBB89E3AE4E77C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B695D60D255627D7042856A5 /* AFHTTPRequestOperation.h in Headers */,
-				2DD91AE0368B9101FEAB9183 /* AFHTTPRequestOperationManager.h in Headers */,
-				B7E92E9F7D15074A24F9A393 /* AFHTTPSessionManager.h in Headers */,
-				7236D89104E74FE6CC656E33 /* AFNetworkActivityIndicatorManager.h in Headers */,
-				7CAC2C24376FC32810482180 /* AFNetworkReachabilityManager.h in Headers */,
-				934EB8E948E8DB1C511D08AE /* AFNetworking.h in Headers */,
-				1A99769664A16FCFF8586789 /* AFSecurityPolicy.h in Headers */,
-				BE8EF19E35611A508B09CFDB /* AFURLConnectionOperation.h in Headers */,
-				654CDBDEFD1ECFB00BCC0081 /* AFURLRequestSerialization.h in Headers */,
-				4C15FFFABFB1085AEF4EC21D /* AFURLResponseSerialization.h in Headers */,
-				ACBCB8011429C1DF7FF847C7 /* AFURLSessionManager.h in Headers */,
-				B98844E12034BE035BC6EA96 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
-				E6C78D411835B9653985367B /* UIAlertView+AFNetworking.h in Headers */,
-				726D57B571D52EEB9CE08FFC /* UIButton+AFNetworking.h in Headers */,
-				1D2A4ED96951A5C333852D48 /* UIImageView+AFNetworking.h in Headers */,
-				43326239801C59BCD048056A /* UIKit+AFNetworking.h in Headers */,
-				EB1488894260938DF9243E20 /* UIProgressView+AFNetworking.h in Headers */,
-				0207DC4E3B2D0C0B9596CDA6 /* UIRefreshControl+AFNetworking.h in Headers */,
-				CC8322E52150569B9A3A9AA5 /* UIWebView+AFNetworking.h in Headers */,
+				E192E1F3ABCB77E39E076B3A /* CLPlacemark+HNKAdditions.h in Headers */,
+				D757B476DE0F9831420E7556 /* HNKGooglePlacesAutocomplete.h in Headers */,
+				27BC068B9E971D9DB83A1301 /* HNKGooglePlacesAutocompleteModel.h in Headers */,
+				A292F25E2837CB05D2A76553 /* HNKGooglePlacesAutocompletePlace.h in Headers */,
+				10E7337DEEDA98273FB66B7B /* HNKGooglePlacesAutocompletePlaceSubstring.h in Headers */,
+				83005DC3672DDE1E56E49169 /* HNKGooglePlacesAutocompletePlaceTerm.h in Headers */,
+				82A8E878274A26D7A99F5087 /* HNKGooglePlacesAutocompleteQuery.h in Headers */,
+				B8E276FABADFF4C5BB2C8B67 /* HNKGooglePlacesAutocompleteQueryConfig.h in Headers */,
+				86186248A47DD1E5E16E485A /* HNKGooglePlacesAutocompleteQueryResponse.h in Headers */,
+				1E7739D0448F046E080DBC74 /* HNKGooglePlacesServer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		45663E8CCF1592FC2C09A6DA /* Headers */ = {
+		91291A51061CF03BD96A637A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FF706F5C100CFE369C6F361C /* EXTKeyPathCoding.h in Headers */,
-				0A4E1CFB3091A82C679316B7 /* EXTRuntimeExtensions.h in Headers */,
-				EE583341AC98CDD913168B32 /* EXTScope.h in Headers */,
-				5266E8699BCEEF1C3BC47FAB /* MTLJSONAdapter.h in Headers */,
-				821F0CBB0B08FB53FAF7D184 /* MTLManagedObjectAdapter.h in Headers */,
-				55A83C021CBE331D7CDBE151 /* MTLModel+NSCoding.h in Headers */,
-				9B2F1E59B50CBCA50F08310F /* MTLModel.h in Headers */,
-				8D5BD25A98558ADE14D24A67 /* MTLReflection.h in Headers */,
-				CF6068133427914D2A984D2E /* MTLValueTransformer.h in Headers */,
-				ADAD81A9E1262882C669F693 /* Mantle.h in Headers */,
-				82561EAEB96DC88B811F9652 /* NSArray+MTLManipulationAdditions.h in Headers */,
-				9856D7935AE09F792F0BC95D /* NSDictionary+MTLManipulationAdditions.h in Headers */,
-				CF535E1B5E6FF2D090517E83 /* NSError+MTLModelException.h in Headers */,
-				9B67961193A6764BF9255F1E /* NSObject+MTLComparisonAdditions.h in Headers */,
-				73EDA0A25F60451F0DAAF4E4 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
-				668D8AC89F22321B1705059A /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
-				E9B6990CB4FF8F6D623C4311 /* metamacros.h in Headers */,
+				EAE04019B282FD5688A9CA61 /* AFHTTPRequestOperation.h in Headers */,
+				F79144976EDEF0BD93A1B68F /* AFHTTPRequestOperationManager.h in Headers */,
+				89AFCD9569CE720A3B11FD0D /* AFHTTPSessionManager.h in Headers */,
+				219BD084081000C266D0E9F2 /* AFNetworkActivityIndicatorManager.h in Headers */,
+				33022AFECA9A9BCDEA7541D0 /* AFNetworkReachabilityManager.h in Headers */,
+				4B9867ECECBABA57E470039A /* AFNetworking.h in Headers */,
+				231684C89567B45C506A1D36 /* AFSecurityPolicy.h in Headers */,
+				77BCDD08450AF4D6BAC4B00A /* AFURLConnectionOperation.h in Headers */,
+				8A06163F924BF6F475FD3BAF /* AFURLRequestSerialization.h in Headers */,
+				CBF1DE2111F3A80F060DC196 /* AFURLResponseSerialization.h in Headers */,
+				BFE8B1B2BE0DD060C30CBB6C /* AFURLSessionManager.h in Headers */,
+				9FCFEC2D41A771115B69FC5F /* UIActivityIndicatorView+AFNetworking.h in Headers */,
+				2BB8BF14FEA31A4822AF9603 /* UIAlertView+AFNetworking.h in Headers */,
+				88F830BF21864CC177139925 /* UIButton+AFNetworking.h in Headers */,
+				3B4E3A047D6A322775E14F21 /* UIImageView+AFNetworking.h in Headers */,
+				3D0510263BAC8D7E8FD79BDF /* UIKit+AFNetworking.h in Headers */,
+				2D610282B0D7D764B76CF049 /* UIProgressView+AFNetworking.h in Headers */,
+				4DFA305BF22B93C838B80B22 /* UIRefreshControl+AFNetworking.h in Headers */,
+				97EBF2A42549A1298CB25CB7 /* UIWebView+AFNetworking.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		573893A469BADA079621CDB8 /* Headers */ = {
+		D04CD82B31DA90D8406D9D29 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D772E0F4A382157FE87D59FD /* KWAfterAllNode.h in Headers */,
-				9A0849A83F622C65BE3B49B1 /* KWAfterEachNode.h in Headers */,
-				0186431A2E6B0567164EBAD3 /* KWAny.h in Headers */,
-				1F4299EAB401953C0ABAE0AD /* KWAsyncVerifier.h in Headers */,
-				E04E16E04C5C8489C6A0D172 /* KWBeBetweenMatcher.h in Headers */,
-				CC4388D8A886D0D6DAA3A164 /* KWBeEmptyMatcher.h in Headers */,
-				0D5ADA939C87F915750DF2B7 /* KWBeIdenticalToMatcher.h in Headers */,
-				CF1292BE6372C2A71E930F3A /* KWBeKindOfClassMatcher.h in Headers */,
-				54FE0644EAB27A7231FAF688 /* KWBeMemberOfClassMatcher.h in Headers */,
-				CACA91A4DFA89BB120ACB65F /* KWBeSubclassOfClassMatcher.h in Headers */,
-				5B3DA34F2F02708050978FFA /* KWBeTrueMatcher.h in Headers */,
-				50F645E0499DF23875A4279D /* KWBeWithinMatcher.h in Headers */,
-				0FB20901A631C87AFB337668 /* KWBeZeroMatcher.h in Headers */,
-				36234F274B7014500A83238D /* KWBeforeAllNode.h in Headers */,
-				8DB04D8DFD9430FAC27D3ED2 /* KWBeforeEachNode.h in Headers */,
-				39B3CE6B183342AFFE970B60 /* KWBlock.h in Headers */,
-				27A7A37A15F433F8716BA0D4 /* KWBlockNode.h in Headers */,
-				F99BF333A2C6A2336437D50F /* KWBlockRaiseMatcher.h in Headers */,
-				290A5A7846EFB3951D85F5C2 /* KWCallSite.h in Headers */,
-				F2D3E6492CF64406D310CDA7 /* KWCaptureSpy.h in Headers */,
-				4ECEABA5D24827D533EFD5D4 /* KWChangeMatcher.h in Headers */,
-				BD8981C41015A05C8923061B /* KWConformToProtocolMatcher.h in Headers */,
-				97EEF2CCFBC1A5FE067A0D20 /* KWContainMatcher.h in Headers */,
-				C6737C80E3F75BE204B8C1E5 /* KWContainStringMatcher.h in Headers */,
-				D42D2822DE347CA96AF8EF93 /* KWContextNode.h in Headers */,
-				BD2147859ED0752D9CDAD95C /* KWCountType.h in Headers */,
-				F42968F591EA3C2ED0CFCE78 /* KWDeviceInfo.h in Headers */,
-				983939BE88A0BA8A8D19E420 /* KWEqualMatcher.h in Headers */,
-				CC8B16C0283D0B981A0F1885 /* KWExample.h in Headers */,
-				B55B1E2DB10CE38B93DC6507 /* KWExampleDelegate.h in Headers */,
-				46F188B9AE105F1C6D2DA0B3 /* KWExampleNode.h in Headers */,
-				787817CFD9E18556FC305267 /* KWExampleNodeVisitor.h in Headers */,
-				53181E4F375F6D4398FF4CCB /* KWExampleSuite.h in Headers */,
-				FCE5516AB52C0D098C83CC40 /* KWExampleSuiteBuilder.h in Headers */,
-				F5113C730DC860A85100BAE3 /* KWExistVerifier.h in Headers */,
-				77D2CFDAA07DE9FA95C5BA2B /* KWExpectationType.h in Headers */,
-				460920A91F4D8A78039A337B /* KWFailure.h in Headers */,
-				99F084B985A12AED04DCCE85 /* KWFormatter.h in Headers */,
-				FCFAC10727967D5361F8F099 /* KWFutureObject.h in Headers */,
-				CC06147C1D2AF40DA493013A /* KWGenericMatchEvaluator.h in Headers */,
-				8E88F6AABB4CCE2F4049D924 /* KWGenericMatcher.h in Headers */,
-				1971FB3C2367772C68E194EB /* KWGenericMatchingAdditions.h in Headers */,
-				43B64D7370A0F2290F4106A6 /* KWHaveMatcher.h in Headers */,
-				270026E4B7176F9A6407C25C /* KWHaveValueMatcher.h in Headers */,
-				49E54B30FA0EF9C42D6F2782 /* KWInequalityMatcher.h in Headers */,
-				0BF6655C6F2AA00E40120D64 /* KWIntercept.h in Headers */,
-				A9D202D2EACF08BFF4684625 /* KWInvocationCapturer.h in Headers */,
-				4465F416C987E7073127A2A1 /* KWItNode.h in Headers */,
-				54DCE210E72826A2475C1FD9 /* KWLet.h in Headers */,
-				FFE0FCB4C458B92C781982F4 /* KWLetNode.h in Headers */,
-				D112079161568757DC4B228A /* KWMatchVerifier.h in Headers */,
-				3CE16D818CA3093C634C40CD /* KWMatcher.h in Headers */,
-				B56ACE7AB2C4964FCEE94E35 /* KWMatcherFactory.h in Headers */,
-				430D76129A6C7AE05CEA4809 /* KWMatchers.h in Headers */,
-				91BC91F76775A0CBBA7DB812 /* KWMatching.h in Headers */,
-				CACAA8EA699F858285DCE492 /* KWMessagePattern.h in Headers */,
-				03FB9BBDC264E3D71EBD92B7 /* KWMessageSpying.h in Headers */,
-				30DA4B0037AD9C2066646AB4 /* KWMessageTracker.h in Headers */,
-				2BD3FAAB7C3860B409BEF746 /* KWMock.h in Headers */,
-				10B44A7FCB26E95005AB26F1 /* KWNilMatcher.h in Headers */,
-				729113935F6E5EF2C31B3DC3 /* KWNotificationMatcher.h in Headers */,
-				CF83FDC7687172E6593BE392 /* KWNull.h in Headers */,
-				62245980218D5964862DFA82 /* KWObjCUtilities.h in Headers */,
-				7F79CB8C9F8CEAB50C89819E /* KWPendingNode.h in Headers */,
-				FC48B26E00A1F7DB9D3222D5 /* KWProbe.h in Headers */,
-				DC4F5A9415F146AC7D19EFC6 /* KWProbePoller.h in Headers */,
-				6B4DB2323820FD024D58BD97 /* KWReceiveMatcher.h in Headers */,
-				8C472AD5499BD999745C22F1 /* KWRegisterMatchersNode.h in Headers */,
-				CF66110B9C47C7A62AFAC5C8 /* KWRegularExpressionPatternMatcher.h in Headers */,
-				215F51990BB4386C1D00BBCA /* KWReporting.h in Headers */,
-				184E13A59F131721738588A7 /* KWRespondToSelectorMatcher.h in Headers */,
-				7AD480C004A0732D468293CC /* KWSpec.h in Headers */,
-				454FC72A0EC8B3D13D1394E6 /* KWStringContainsMatcher.h in Headers */,
-				556FCA8A41069FC7B93722E7 /* KWStringPrefixMatcher.h in Headers */,
-				9A2F9BCDE4A6A0BC7137FDD4 /* KWStringUtilities.h in Headers */,
-				59EA03B14176D861872C09A7 /* KWStub.h in Headers */,
-				DD52DA8D049C86C6A3932027 /* KWSuiteConfigurationBase.h in Headers */,
-				E72F87F28D0DC272D4E459EB /* KWSymbolicator.h in Headers */,
-				2D7CA6FD97CCC15745E84762 /* KWUserDefinedMatcher.h in Headers */,
-				7B05B677571D01D1137F2335 /* KWValue.h in Headers */,
-				DBA8E1707AEA5215D6E6A8C0 /* KWVerifying.h in Headers */,
-				6F90CA746AF38566A4BE3D5C /* KWWorkarounds.h in Headers */,
-				351D6345F22584E7D78B72D6 /* Kiwi.h in Headers */,
-				D6174C95CE0F04C5FB2A7500 /* KiwiBlockMacros.h in Headers */,
-				ABEDC20A90DEE67D3E3A1DA0 /* KiwiConfiguration.h in Headers */,
-				ADC723185E84C3771452D195 /* KiwiMacros.h in Headers */,
-				BDE81B303855F9DF9CC88ED3 /* NSInvocation+KiwiAdditions.h in Headers */,
-				41303E590980FE7753F04B6E /* NSInvocation+OCMAdditions.h in Headers */,
-				E58CFE7D6EEE61BC37E2702C /* NSMethodSignature+KiwiAdditions.h in Headers */,
-				D40E909594A8AC76D2246D1B /* NSNumber+KiwiAdditions.h in Headers */,
-				A050A6DD97E83E1F5FA70168 /* NSObject+KiwiMockAdditions.h in Headers */,
-				A59361F5244FCDD35AC50D1A /* NSObject+KiwiSpyAdditions.h in Headers */,
-				F819734B186C06A4DE7A2997 /* NSObject+KiwiStubAdditions.h in Headers */,
-				59E6CF352EE25061BB9FE1B3 /* NSObject+KiwiVerifierAdditions.h in Headers */,
-				C03C1BBD57A0AA6F41667EC5 /* NSProxy+KiwiVerifierAdditions.h in Headers */,
-				2ADEC9B17793A2501A2A61BD /* NSValue+KiwiAdditions.h in Headers */,
+				6C96F298368D6E51A4447F5E /* HNKServer.h in Headers */,
+				73E56A03712BCFB1DC4E5C1B /* HNKServerFacade.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		61748ED47ACDDBE4BCCA265C /* Headers */ = {
+		D6A5D49076141DE45078853E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6AA6B434195F161F8A71BC35 /* CLPlacemark+HNKAdditions.h in Headers */,
-				358BB24E7E308C3BB1E6C7EE /* HNKGooglePlacesAutocomplete.h in Headers */,
-				5FC54F45D720DFAB04E76189 /* HNKGooglePlacesAutocompleteModel.h in Headers */,
-				6E3A7826D8C9F5868BEC96C3 /* HNKGooglePlacesAutocompletePlace.h in Headers */,
-				F5DC509F927E996D6DFA557F /* HNKGooglePlacesAutocompletePlaceSubstring.h in Headers */,
-				8004CDC36C6EB350002F336F /* HNKGooglePlacesAutocompletePlaceTerm.h in Headers */,
-				6F133AE7BC2E40FAA2D0B16C /* HNKGooglePlacesAutocompleteQuery.h in Headers */,
-				42F2495701122EA37346C157 /* HNKGooglePlacesAutocompleteQueryConfig.h in Headers */,
-				F973E950711AB175D6CAFDF4 /* HNKGooglePlacesAutocompleteQueryResponse.h in Headers */,
-				F84D791EEA72B12790C30E67 /* HNKGooglePlacesServer.h in Headers */,
+				F380A90C1557D846A03F232A /* EXTKeyPathCoding.h in Headers */,
+				D9DC6A2E15F52E58D684F5BF /* EXTRuntimeExtensions.h in Headers */,
+				BEDBB6F3E4A24084317E9136 /* EXTScope.h in Headers */,
+				CCBC4A54FD4C9B2861845CD1 /* MTLJSONAdapter.h in Headers */,
+				ECF6208532B1C74DAD23C3F0 /* MTLManagedObjectAdapter.h in Headers */,
+				583801CD7D95360E29D1022A /* MTLModel+NSCoding.h in Headers */,
+				70F333E771024B7F7853F16A /* MTLModel.h in Headers */,
+				1638B24CECC3B025A07832F4 /* MTLReflection.h in Headers */,
+				16E75DB1E7BA2C3DB8D32B02 /* MTLValueTransformer.h in Headers */,
+				4E0D7BC53C507859E299BE58 /* Mantle.h in Headers */,
+				E0B8604760A6179FABD221D2 /* NSArray+MTLManipulationAdditions.h in Headers */,
+				DF5887CFF1C2BDDA3D9BD47F /* NSDictionary+MTLManipulationAdditions.h in Headers */,
+				8588DE2F8A1D92854BA59469 /* NSError+MTLModelException.h in Headers */,
+				A7BAFA773976B05287EB6A59 /* NSObject+MTLComparisonAdditions.h in Headers */,
+				4764AF2B319E56D7C243CB79 /* NSValueTransformer+MTLInversionAdditions.h in Headers */,
+				3B97F00162765877748ACA95 /* NSValueTransformer+MTLPredefinedTransformerAdditions.h in Headers */,
+				8827A80B6314BC8FC62ADBEA /* metamacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		034FB013203F9B69EA889C90 /* Pods-HNKGooglePlacesAutocomplete-Example */ = {
+		3980640E62AEEFF342677376 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 665E7E6C33A1ABDA2AFDCE06 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example" */;
+			buildConfigurationList = 3FF9FC2E12DDFC406B213603 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking" */;
 			buildPhases = (
-				3365CA16E659E5FF9A8E56DC /* Sources */,
-				FA2FDFB6F07A2D987118EC06 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				717F8E1F0BFA920A724EA5A3 /* PBXTargetDependency */,
-				FC2B115A7D0A1CAC86F1F489 /* PBXTargetDependency */,
-				EF2316B1C841821055110353 /* PBXTargetDependency */,
-				F35563B56330BAC64A83A2C4 /* PBXTargetDependency */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-Example";
-			productName = "Pods-HNKGooglePlacesAutocomplete-Example";
-			productReference = EE7A9058CDD102A5B6C74A36 /* libPods-HNKGooglePlacesAutocomplete-Example.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		220B5C0ED3A2349694FDC974 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 015C0FE4024D6EFFA3F27175 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade" */;
-			buildPhases = (
-				BE4C613FF7C5F30456C5146C /* Sources */,
-				643E8C20794C365D15AC58A6 /* Frameworks */,
-				066626A993809813953C9B97 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				6B207F7D0671E437313C6E6E /* PBXTargetDependency */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
-			productName = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
-			productReference = CD57BDC361AF3A229800C9E8 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		542726CE34D02AF7E45A9996 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 86BE350412EB1C792121891B /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi" */;
-			buildPhases = (
-				24AA555445786BA355E8792E /* Sources */,
-				6BDBE5C49A46035FEECEC98C /* Frameworks */,
-				573893A469BADA079621CDB8 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
-			productName = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
-			productReference = 3C0B2189DE86ED20A3BAD445 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		5D03E40D2B206B4F0239D0B3 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0F49CA2569DCB677EF743D46 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-Mantle" */;
-			buildPhases = (
-				20943B4FC207688400032197 /* Sources */,
-				AD3D5012AC6B32032A1ED830 /* Frameworks */,
-				45663E8CCF1592FC2C09A6DA /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
-			productName = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
-			productReference = 1D99D6813A6071660B5ED853 /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		5D72EAA7B58CC8E90E3DCBA5 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B01AED520791D19D1422B068 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests" */;
-			buildPhases = (
-				EF45AF3C44D22D686501E1F0 /* Sources */,
-				B369382AE863B8F9D3A10F98 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				71C22B1275023C799455A3EF /* PBXTargetDependency */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
-			productName = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
-			productReference = 671B91C3BA65219D4629CAD9 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		8AB39843A51D427DA606B574 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B1CB54063CFC4271E434C074 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete" */;
-			buildPhases = (
-				CB8AE308EC95300247D95BA3 /* Sources */,
-				21A2BBDF5041D8496B6C18AF /* Frameworks */,
-				61748ED47ACDDBE4BCCA265C /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				7FC4DAE18AD8444B547D769B /* PBXTargetDependency */,
-				59DB4995D79E0F56C8ED3072 /* PBXTargetDependency */,
-			);
-			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
-			productName = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
-			productReference = 3841EF67FE7179A68A84E0AE /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		C0B3D285938CDBD7C09C3320 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8153EBC87F022E18B83D7BD6 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking" */;
-			buildPhases = (
-				FB0D2C9B7EFB39A9A747C7CA /* Sources */,
-				5271CCBD72CCF3B6EA2FA1CF /* Frameworks */,
-				15074D013C76834B4E9817B2 /* Headers */,
+				835F3A5EFA8BCD4BCC1C7C8F /* Sources */,
+				A049745E2F9029125C7679BE /* Frameworks */,
+				91291A51061CF03BD96A637A /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1580,291 +1472,415 @@
 			);
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
 			productName = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
-			productReference = 9327B768AF5A3B77476DAAC6 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */;
+			productReference = 631F4A85166DA19B140AAF06 /* libPods-HNKGooglePlacesAutocomplete-Example-AFNetworking.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		5F8653000638B4C4125103D7 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 72BB5D234952E4E950F963E9 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete" */;
+			buildPhases = (
+				90235FDBB0DD6BFF7985C23A /* Sources */,
+				B59A1395DFC09827557C63FC /* Frameworks */,
+				7E59897E45CBB89E3AE4E77C /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ED1F3D777C672C2A9EA92141 /* PBXTargetDependency */,
+				7047DF5936ED84A17B31EA68 /* PBXTargetDependency */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
+			productName = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
+			productReference = D252F0F6E6E6678CA1E5D9D3 /* libPods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		6498242C45A38780A3C09F81 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C4773A57D8C41545F7EC34BE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-Mantle" */;
+			buildPhases = (
+				59023CDA6A27A82D0D3A7D5B /* Sources */,
+				9CECE295E022682617BF3547 /* Frameworks */,
+				D6A5D49076141DE45078853E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
+			productName = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
+			productReference = 39320D3F8464D4AD985D1A6A /* libPods-HNKGooglePlacesAutocomplete-Example-Mantle.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7050BC36E0B53A3DE6CE4067 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2475243F5275DE1D3CD7F6FE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests" */;
+			buildPhases = (
+				AF9EE5CEB4FFF1051CB918F6 /* Sources */,
+				CB82BE4CBE6D5D4E71D2F8C1 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				645200F97D04D042D829DD9E /* PBXTargetDependency */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
+			productName = "Pods-HNKGooglePlacesAutocomplete-ExampleTests";
+			productReference = 5F78D1C482590761967E5705 /* libPods-HNKGooglePlacesAutocomplete-ExampleTests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		802B8D549401A7263AB506AE /* Pods-HNKGooglePlacesAutocomplete-Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AD39456912062B7724FC995B /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example" */;
+			buildPhases = (
+				42FBA793CC8299205754852C /* Sources */,
+				106D2C75BBA57256C2C1A6B0 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				42DDD3B5435495C0244A125C /* PBXTargetDependency */,
+				C3FE29B8ABA8D0FCF370CCD0 /* PBXTargetDependency */,
+				851A1DB96791849E8F04400C /* PBXTargetDependency */,
+				0C847BDC8F9B904952312A12 /* PBXTargetDependency */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-Example";
+			productName = "Pods-HNKGooglePlacesAutocomplete-Example";
+			productReference = F1E2D7F256FB4DE806130029 /* libPods-HNKGooglePlacesAutocomplete-Example.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C000419035B9E6734FF11DAF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0DB501EDC622F578DC6422CE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade" */;
+			buildPhases = (
+				857110102F3D5F54493118D5 /* Sources */,
+				3352B6614B6D2A42C044BA00 /* Frameworks */,
+				D04CD82B31DA90D8406D9D29 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				474DD8599E3700A09021FCA0 /* PBXTargetDependency */,
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
+			productName = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
+			productReference = 0A7A873270F44E276387B15A /* libPods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		CF63059F21D3520300C09AD3 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 72743F44B855A7D6C858489C /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi" */;
+			buildPhases = (
+				9863B585F3432DC9BD749376 /* Sources */,
+				59B422518A576CDF9FC9F636 /* Frameworks */,
+				3112A3A48B76313F93E2007E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
+			productName = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
+			productReference = A8269E21D05170FF6B63BB4A /* libPods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		6693617DAA1242D75F0C3B4F /* Project object */ = {
+		15402930F01A4867F7C30448 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = 64B7DF62CDC7AC61B77C99AC /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 8411F9522690FB5E731FFCA8 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 77AD4157F0D75AE7E79D2B13;
-			productRefGroup = 1DB5BE5E55305869B7F2AB2E /* Products */;
+			mainGroup = 701D5462312D47D05ABA8F80;
+			productRefGroup = 8E73BABAF6B630D8FB139ABB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				034FB013203F9B69EA889C90 /* Pods-HNKGooglePlacesAutocomplete-Example */,
-				C0B3D285938CDBD7C09C3320 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */,
-				8AB39843A51D427DA606B574 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */,
-				220B5C0ED3A2349694FDC974 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */,
-				5D03E40D2B206B4F0239D0B3 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */,
-				5D72EAA7B58CC8E90E3DCBA5 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */,
-				542726CE34D02AF7E45A9996 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */,
+				802B8D549401A7263AB506AE /* Pods-HNKGooglePlacesAutocomplete-Example */,
+				3980640E62AEEFF342677376 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */,
+				5F8653000638B4C4125103D7 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */,
+				C000419035B9E6734FF11DAF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */,
+				6498242C45A38780A3C09F81 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */,
+				7050BC36E0B53A3DE6CE4067 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests */,
+				CF63059F21D3520300C09AD3 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		20943B4FC207688400032197 /* Sources */ = {
+		42FBA793CC8299205754852C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FFD06C32B26204726B7A16D2 /* EXTRuntimeExtensions.m in Sources */,
-				61A29A4FFD4BCE6051B4C251 /* EXTScope.m in Sources */,
-				651210AB82713AABD7D38EB9 /* MTLJSONAdapter.m in Sources */,
-				D2E1DF99337A4D219CFF7DB1 /* MTLManagedObjectAdapter.m in Sources */,
-				443B185370E5F244B4F2C2EE /* MTLModel+NSCoding.m in Sources */,
-				60E143C04011C676802C64BC /* MTLModel.m in Sources */,
-				753C80342644569157983FA8 /* MTLReflection.m in Sources */,
-				E26A971052A40047405A1541 /* MTLValueTransformer.m in Sources */,
-				274BED1EDB475BE2CD935BD8 /* NSArray+MTLManipulationAdditions.m in Sources */,
-				3CCE37374C0F43A8834D262E /* NSDictionary+MTLManipulationAdditions.m in Sources */,
-				818A94765F00543868366903 /* NSError+MTLModelException.m in Sources */,
-				0440023F7AEC1CA1CCE1A8EA /* NSObject+MTLComparisonAdditions.m in Sources */,
-				F21F97487F8AACC73DBB81BC /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
-				B921E775EA6D73B1F05EE9A9 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
-				D739C2436A629CB2517F448D /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m in Sources */,
+				0C8113334CC68F2E5E750BB9 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		24AA555445786BA355E8792E /* Sources */ = {
+		59023CDA6A27A82D0D3A7D5B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E715DB0E1F49AE99ABE805FD /* KWAfterAllNode.m in Sources */,
-				DE935D77F5709A3527905B66 /* KWAfterEachNode.m in Sources */,
-				C84E596A1B787A17605FB017 /* KWAllTestsSuite.m in Sources */,
-				F864A5714EBB0C2372825456 /* KWAny.m in Sources */,
-				0C856708673CEB2980D1F201 /* KWAsyncVerifier.m in Sources */,
-				8609F970DD4927D64E9B52C9 /* KWBeBetweenMatcher.m in Sources */,
-				3135E978EBBF2509B600E5B0 /* KWBeEmptyMatcher.m in Sources */,
-				B4E9FAEC7315D229D1DBF9B4 /* KWBeIdenticalToMatcher.m in Sources */,
-				5A8E9AE7518C43A22DC9A4BF /* KWBeKindOfClassMatcher.m in Sources */,
-				289D279A4F9E60F99158E448 /* KWBeMemberOfClassMatcher.m in Sources */,
-				603BA07F0C9DF16D72043DED /* KWBeSubclassOfClassMatcher.m in Sources */,
-				A2511FD5C6501E6E1D6C4346 /* KWBeTrueMatcher.m in Sources */,
-				556B569DDB1CF6C64F24DB3C /* KWBeWithinMatcher.m in Sources */,
-				9DFBCFA9C7A662E0C2E2B542 /* KWBeZeroMatcher.m in Sources */,
-				6E19857E2111A31763E49B1A /* KWBeforeAllNode.m in Sources */,
-				B066AFE74F1BC5E75E517610 /* KWBeforeEachNode.m in Sources */,
-				41C5B353FB791A8A28666BAD /* KWBlock.m in Sources */,
-				0C31D06E05B5F6EE138D334E /* KWBlockNode.m in Sources */,
-				4A99BC6A490CEB8430E34F48 /* KWBlockRaiseMatcher.m in Sources */,
-				87FEC0A0A686EB3CCDA77AB7 /* KWCallSite.m in Sources */,
-				F05703B22B95462CB73D6681 /* KWCaptureSpy.m in Sources */,
-				E91251FFA07C3000C683EA19 /* KWChangeMatcher.m in Sources */,
-				14E639FD0EAA1496230AB022 /* KWConformToProtocolMatcher.m in Sources */,
-				8EF103106B52CA834E93E10C /* KWContainMatcher.m in Sources */,
-				99451DCB4B876A1F8ED0048B /* KWContainStringMatcher.m in Sources */,
-				0428FC8A0C9C5FF8E99071A2 /* KWContextNode.m in Sources */,
-				078CA897AF09CFD06CCE7A3D /* KWDeviceInfo.m in Sources */,
-				58CA0FB77D75B490E822FF74 /* KWEqualMatcher.m in Sources */,
-				87437DD5111042857BA4CEF8 /* KWExample.m in Sources */,
-				9E807CA7A58F06802CBA2060 /* KWExampleSuite.m in Sources */,
-				58E6992A091EFE2771C97A8E /* KWExampleSuiteBuilder.m in Sources */,
-				210CAECA7BDF81CA5441BA2E /* KWExistVerifier.m in Sources */,
-				612615A30098EDBB4D04C6E1 /* KWFailure.m in Sources */,
-				AB7D9C2DB5F1E4D9D0528073 /* KWFormatter.m in Sources */,
-				08F416176528016F6E71F274 /* KWFutureObject.m in Sources */,
-				8ABEF860233BAA88D15689A5 /* KWGenericMatchEvaluator.m in Sources */,
-				78CFCBC8DCF6CF385E1781E4 /* KWGenericMatcher.m in Sources */,
-				8D7D716E927CD5C08038CE2B /* KWGenericMatchingAdditions.m in Sources */,
-				A43DEA7EBA75CF9D3F84F7C0 /* KWHaveMatcher.m in Sources */,
-				60541FC1651BAC5D0F4BA229 /* KWHaveValueMatcher.m in Sources */,
-				6059EC276786CEA1167712FF /* KWInequalityMatcher.m in Sources */,
-				C0B515554A8925E15502DB92 /* KWIntercept.m in Sources */,
-				73B8796EB4907890E8F8CD7E /* KWInvocationCapturer.m in Sources */,
-				05568F097AE470A9AB45CB5F /* KWItNode.m in Sources */,
-				4FD7649DD8B8E41B61DEF71B /* KWLetNode.m in Sources */,
-				AE6222FF1A1E0D6B8AC536E4 /* KWMatchVerifier.m in Sources */,
-				08539F66344FDB82F68AF3BD /* KWMatcher.m in Sources */,
-				6D05EFEDC95B97D875D92565 /* KWMatcherFactory.m in Sources */,
-				B812259E4268BA18ACF91B10 /* KWMatchers.m in Sources */,
-				D67467BECD94488910074B8D /* KWMessagePattern.m in Sources */,
-				6B2C625F0A0DE0736FFEFF98 /* KWMessageTracker.m in Sources */,
-				BC6A136F71A1AC97AB32B67B /* KWMock.m in Sources */,
-				6F3DC6B61E7BA37A41F2F94F /* KWNilMatcher.m in Sources */,
-				9B5ABC604F60A9A020C05423 /* KWNotificationMatcher.m in Sources */,
-				DE85DD2602AD9006930F2EBE /* KWNull.m in Sources */,
-				D5765D3C17A54A008CA7DD6D /* KWObjCUtilities.m in Sources */,
-				9191930DA58E5A4FBC1502AE /* KWPendingNode.m in Sources */,
-				3167A6FC3863B1F828ED47F4 /* KWProbePoller.m in Sources */,
-				70C285E3017754F0EA9C3B3B /* KWReceiveMatcher.m in Sources */,
-				043469FCB03DFC7EBFDF623A /* KWRegisterMatchersNode.m in Sources */,
-				344A12F6347E58A6E0CA5BB6 /* KWRegularExpressionPatternMatcher.m in Sources */,
-				D6B08FDD53E3C7BF34562FB7 /* KWRespondToSelectorMatcher.m in Sources */,
-				3042D7149B1A58D4C894421B /* KWSpec.m in Sources */,
-				638AF0D359F20134242F507F /* KWStringContainsMatcher.m in Sources */,
-				C32D89F7081AE79881D4C269 /* KWStringPrefixMatcher.m in Sources */,
-				0149F2D3006C861562D19498 /* KWStringUtilities.m in Sources */,
-				5A49DC343EC4B78AEABBBD72 /* KWStub.m in Sources */,
-				98DE5D6AC29595D3986485C2 /* KWSuiteConfigurationBase.m in Sources */,
-				8666475F5BAA51ADC1E53723 /* KWSymbolicator.m in Sources */,
-				4E7843DD35D9AD5264F632B9 /* KWUserDefinedMatcher.m in Sources */,
-				3FCF623FCCEF425E43FA8995 /* KWValue.m in Sources */,
-				7906E1C251902AF82635C2E1 /* KWWorkarounds.m in Sources */,
-				6F6F91D8D1E225677910B235 /* NSInvocation+KiwiAdditions.m in Sources */,
-				CFB7FE8E436F29174BE5165F /* NSInvocation+OCMAdditions.m in Sources */,
-				385002FE848FEE21EDB4A995 /* NSMethodSignature+KiwiAdditions.m in Sources */,
-				83E0337A28F86BEB84AD4315 /* NSNumber+KiwiAdditions.m in Sources */,
-				90CAF0DDC0C056893E414CBF /* NSObject+KiwiMockAdditions.m in Sources */,
-				4E0D357C02E50E3F8655B630 /* NSObject+KiwiSpyAdditions.m in Sources */,
-				4A1B6DD3D32FCABD42CFB4C3 /* NSObject+KiwiStubAdditions.m in Sources */,
-				F71E69A3BEE32D549F298384 /* NSObject+KiwiVerifierAdditions.m in Sources */,
-				04E25FBE750A883CF2C04A11 /* NSProxy+KiwiVerifierAdditions.m in Sources */,
-				E45BB6FECCE0A94567870364 /* NSValue+KiwiAdditions.m in Sources */,
-				986244AAE0A23E843857B8D5 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m in Sources */,
+				85B7ED1263EB7CC0127526B2 /* EXTRuntimeExtensions.m in Sources */,
+				EE3584BEE639300F1ADB5359 /* EXTScope.m in Sources */,
+				D1A9E19EDFC64BABACD86551 /* MTLJSONAdapter.m in Sources */,
+				DB883C466CBC44AB3487F861 /* MTLManagedObjectAdapter.m in Sources */,
+				E5AE603D0A8C7ED90695CC38 /* MTLModel+NSCoding.m in Sources */,
+				72885257213A12C9459DAF74 /* MTLModel.m in Sources */,
+				46A3A13DE5A4E47D3B5F7D8E /* MTLReflection.m in Sources */,
+				E1EDDA3E2A44B8FCD777E25F /* MTLValueTransformer.m in Sources */,
+				377E607E19790F7F841D2515 /* NSArray+MTLManipulationAdditions.m in Sources */,
+				2133DEB6A315A2772A027437 /* NSDictionary+MTLManipulationAdditions.m in Sources */,
+				BFC4D7D496B55C5EE6AA038E /* NSError+MTLModelException.m in Sources */,
+				E2A8660F36DDBE785BA1502A /* NSObject+MTLComparisonAdditions.m in Sources */,
+				4C4DD4F27ECE992FCEDE78DD /* NSValueTransformer+MTLInversionAdditions.m in Sources */,
+				673F8BDB546A41D1357E3B39 /* NSValueTransformer+MTLPredefinedTransformerAdditions.m in Sources */,
+				1696C55FF62281365ADA75DD /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3365CA16E659E5FF9A8E56DC /* Sources */ = {
+		835F3A5EFA8BCD4BCC1C7C8F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76569031B5EE46DC91234876 /* Pods-HNKGooglePlacesAutocomplete-Example-dummy.m in Sources */,
+				956B487E02CCC97C5D559C01 /* AFHTTPRequestOperation.m in Sources */,
+				11EF73482EA1088E3A7D19F2 /* AFHTTPRequestOperationManager.m in Sources */,
+				63550D7DCAFD042FCD5D4190 /* AFHTTPSessionManager.m in Sources */,
+				565E62B3F4FC3F3C5CE53543 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				4FBE51DED310F222380FFCBF /* AFNetworkReachabilityManager.m in Sources */,
+				CA968517A0BBA6E1B6DA0E69 /* AFSecurityPolicy.m in Sources */,
+				2834220C42F44D7F5928C39B /* AFURLConnectionOperation.m in Sources */,
+				9879CC5A789E5A9CFCFB3021 /* AFURLRequestSerialization.m in Sources */,
+				8F1798BD4D0189AF7E7B8087 /* AFURLResponseSerialization.m in Sources */,
+				C45174A90BE17123510D7CF5 /* AFURLSessionManager.m in Sources */,
+				D0CAE87B31D527BFE871A379 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m in Sources */,
+				7E99559A05360109939216F8 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
+				4DEF7CD8F0D049880EA9BEDF /* UIAlertView+AFNetworking.m in Sources */,
+				23FEAF554E5C0F0A6F1B9F6B /* UIButton+AFNetworking.m in Sources */,
+				96C0467B97DDF2EFA474E5ED /* UIImageView+AFNetworking.m in Sources */,
+				F5DE2EC70F9E10767AA0A1AA /* UIProgressView+AFNetworking.m in Sources */,
+				53BDAC696D282AC7EE789B25 /* UIRefreshControl+AFNetworking.m in Sources */,
+				E51F463DBE15D0FE5467F648 /* UIWebView+AFNetworking.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BE4C613FF7C5F30456C5146C /* Sources */ = {
+		857110102F3D5F54493118D5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C566A14118E42AF1DF212726 /* HNKServer.m in Sources */,
-				9CDBF497D9AE3A272A70B347 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m in Sources */,
+				3E4FD2F7C1461493CEE040D6 /* HNKServer.m in Sources */,
+				FE15B862A08501CEDC3AF3DA /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CB8AE308EC95300247D95BA3 /* Sources */ = {
+		90235FDBB0DD6BFF7985C23A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4C221581941530FF3130F501 /* CLPlacemark+HNKAdditions.m in Sources */,
-				86A5FA12B21E94E61B95E3C8 /* HNKGooglePlacesAutocompleteModel.m in Sources */,
-				85CC7479097E6171A8EA5089 /* HNKGooglePlacesAutocompletePlace.m in Sources */,
-				21A0A0F12BE5EDF743BD632E /* HNKGooglePlacesAutocompletePlaceSubstring.m in Sources */,
-				9F0D6587D20347BB4C58AAB0 /* HNKGooglePlacesAutocompletePlaceTerm.m in Sources */,
-				FBE51CDF0A763F4860377D10 /* HNKGooglePlacesAutocompleteQuery.m in Sources */,
-				E912E00D5FE032F908494F4F /* HNKGooglePlacesAutocompleteQueryConfig.m in Sources */,
-				F34D0B6E2788C8BF597D6BAB /* HNKGooglePlacesAutocompleteQueryResponse.m in Sources */,
-				06772C878460AB3F929119F6 /* HNKGooglePlacesServer.m in Sources */,
-				6CD1C0EAAC46270E9A217587 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m in Sources */,
+				8A25711CBB2B09B8BD1A2136 /* CLPlacemark+HNKAdditions.m in Sources */,
+				2E3E0CEF70E7CFBC7EED0DD3 /* HNKGooglePlacesAutocompleteModel.m in Sources */,
+				9C881BDA11B6CEB90C96D7CD /* HNKGooglePlacesAutocompletePlace.m in Sources */,
+				5C4661291AB67A7A08C11DD2 /* HNKGooglePlacesAutocompletePlaceSubstring.m in Sources */,
+				C3263C5CF976CCCB345E03D4 /* HNKGooglePlacesAutocompletePlaceTerm.m in Sources */,
+				F8EAFF5E395000E2B6509934 /* HNKGooglePlacesAutocompleteQuery.m in Sources */,
+				74FB080E01BA43B188E69585 /* HNKGooglePlacesAutocompleteQueryConfig.m in Sources */,
+				0E8F17FE02F91AED96DEEAC2 /* HNKGooglePlacesAutocompleteQueryResponse.m in Sources */,
+				EE6469D34FAD9B88A422D157 /* HNKGooglePlacesServer.m in Sources */,
+				235D59747581393308215270 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EF45AF3C44D22D686501E1F0 /* Sources */ = {
+		9863B585F3432DC9BD749376 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				073F62287AC0C2E4D1A3868F /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m in Sources */,
+				BA50AAD1210F728FFE920F60 /* KWAfterAllNode.m in Sources */,
+				DD44E52E962B0771F111DC07 /* KWAfterEachNode.m in Sources */,
+				06B185ECD0991AEBDAADB1B0 /* KWAllTestsSuite.m in Sources */,
+				612FFC4DADFF94349F91BC5C /* KWAny.m in Sources */,
+				7F99319E041D9899E9E1EA89 /* KWAsyncVerifier.m in Sources */,
+				76F21BD050734EC9E071AFF0 /* KWBeBetweenMatcher.m in Sources */,
+				CCF89CE397BB63A25A5D01E9 /* KWBeEmptyMatcher.m in Sources */,
+				ED1EFD93328EF5534F2A0295 /* KWBeIdenticalToMatcher.m in Sources */,
+				42E3C6B75FB7C9771388C13A /* KWBeKindOfClassMatcher.m in Sources */,
+				1403AE40AE3CA9902FCE8657 /* KWBeMemberOfClassMatcher.m in Sources */,
+				18106747F28DFDF878CD7BDC /* KWBeSubclassOfClassMatcher.m in Sources */,
+				48FD973736DDB78A8B56D394 /* KWBeTrueMatcher.m in Sources */,
+				1C77438731520FF4FCB98D91 /* KWBeWithinMatcher.m in Sources */,
+				56571B9CA917B469CC7E2CD3 /* KWBeZeroMatcher.m in Sources */,
+				654692F81F6024BA1DAC8381 /* KWBeforeAllNode.m in Sources */,
+				B0F94E03AE71CE46919CD0E2 /* KWBeforeEachNode.m in Sources */,
+				47883EF254BF1125C4919AC1 /* KWBlock.m in Sources */,
+				839B9EACFCCD71A14DCFC507 /* KWBlockNode.m in Sources */,
+				1AEF02B141753F1A9560821F /* KWBlockRaiseMatcher.m in Sources */,
+				777576803A40C43E85298E69 /* KWCallSite.m in Sources */,
+				B3654283E3EF4425F0A7D01E /* KWCaptureSpy.m in Sources */,
+				8B88783B28AFDF02855B0220 /* KWChangeMatcher.m in Sources */,
+				0216303B07926FDCB5278078 /* KWConformToProtocolMatcher.m in Sources */,
+				EC190C7D6BFE73D642288E29 /* KWContainMatcher.m in Sources */,
+				7D1372486C15FE773A119107 /* KWContainStringMatcher.m in Sources */,
+				68D5803B56880374A95ACA85 /* KWContextNode.m in Sources */,
+				E52211B4C42F38394474C29A /* KWDeviceInfo.m in Sources */,
+				B9E965492A7BACEEC5CDC644 /* KWEqualMatcher.m in Sources */,
+				651CB2AC865F9E06C4353545 /* KWExample.m in Sources */,
+				0F5FB65F16266036EE3E98FE /* KWExampleSuite.m in Sources */,
+				11F8BB44321A3CB95BD01F3A /* KWExampleSuiteBuilder.m in Sources */,
+				78F1BD0483197D6356F233C5 /* KWExistVerifier.m in Sources */,
+				A52F5DBEA7B9D231FA33A396 /* KWFailure.m in Sources */,
+				86D5233C5DF4E2248C775C3E /* KWFormatter.m in Sources */,
+				CD4FBCA2E828F0EDB2159B8E /* KWFutureObject.m in Sources */,
+				76E6CDAC819838288F010557 /* KWGenericMatchEvaluator.m in Sources */,
+				04D102C6E0EAF455236101DD /* KWGenericMatcher.m in Sources */,
+				A3DDB1CD3D4B95FAF268FC2C /* KWGenericMatchingAdditions.m in Sources */,
+				5CD23C552D260E40ED62B390 /* KWHaveMatcher.m in Sources */,
+				0105C638D911E3799E2482A6 /* KWHaveValueMatcher.m in Sources */,
+				910FFE685DEC2FB272590FD6 /* KWInequalityMatcher.m in Sources */,
+				28A40FAAFFDC7D85A4AD6F63 /* KWIntercept.m in Sources */,
+				328750F060ACBD4BE7CDB6A6 /* KWInvocationCapturer.m in Sources */,
+				929785D5C80A7D5C165F6358 /* KWItNode.m in Sources */,
+				72E2D911C82CD608A5A794E1 /* KWLetNode.m in Sources */,
+				B6D49DC7AC2AE205F45D47BD /* KWMatchVerifier.m in Sources */,
+				8748720DCD239DC70CCA5D47 /* KWMatcher.m in Sources */,
+				F4819F8A5E0BD3E138C8C375 /* KWMatcherFactory.m in Sources */,
+				E1D3C1F048B787BC03DEA100 /* KWMatchers.m in Sources */,
+				1CAEDE2BD5B845FB900B1278 /* KWMessagePattern.m in Sources */,
+				0A4F38369EA3A3212B75EFAB /* KWMessageTracker.m in Sources */,
+				198C0BEF2A9791EE76477667 /* KWMock.m in Sources */,
+				C9E33DC28F651B846506BC21 /* KWNilMatcher.m in Sources */,
+				9D591E5DDB9CA0ECDEB27E06 /* KWNotificationMatcher.m in Sources */,
+				6ECD4C5C2A592498E712D071 /* KWNull.m in Sources */,
+				9F2A926237FC27E5B27B5C68 /* KWObjCUtilities.m in Sources */,
+				C320757E7F70560B5DCF2E99 /* KWPendingNode.m in Sources */,
+				09A31D061AD02E2E4DCFEC98 /* KWProbePoller.m in Sources */,
+				CE222BEC54B40B86E22E9496 /* KWReceiveMatcher.m in Sources */,
+				3A35DD3BEE525B55F13DF54E /* KWRegisterMatchersNode.m in Sources */,
+				9A6C8829E87199F399693502 /* KWRegularExpressionPatternMatcher.m in Sources */,
+				B2A2854FE9D11C26557F8E9F /* KWRespondToSelectorMatcher.m in Sources */,
+				C41152A5B2F9FD3DF91B46B5 /* KWSpec.m in Sources */,
+				7ECD7DEA60A283EAABCE59E3 /* KWStringContainsMatcher.m in Sources */,
+				BDE318B9D5FE435A18F1A1B1 /* KWStringPrefixMatcher.m in Sources */,
+				F2BD70343CEBA0A855677E65 /* KWStringUtilities.m in Sources */,
+				5B0F4F580A6B5FC325508224 /* KWStub.m in Sources */,
+				6DFE093A4994B92EA4B28E24 /* KWSuiteConfigurationBase.m in Sources */,
+				40C0C1F601987D4E8FC9BFB1 /* KWSymbolicator.m in Sources */,
+				9478C7C5159399C0B610D975 /* KWUserDefinedMatcher.m in Sources */,
+				22D3E8BD002B51386F1C6C5F /* KWValue.m in Sources */,
+				2D853DB923AE6517F68CCDCC /* KWWorkarounds.m in Sources */,
+				FED519B05E68FD03951236F5 /* NSInvocation+KiwiAdditions.m in Sources */,
+				9F2DAFFBDBE6B937A9E044B9 /* NSInvocation+OCMAdditions.m in Sources */,
+				019DB40870B3A3CB67BE19E3 /* NSMethodSignature+KiwiAdditions.m in Sources */,
+				E3A7A455EB5A2EED3FD75481 /* NSNumber+KiwiAdditions.m in Sources */,
+				719061C263364EA06B0760EF /* NSObject+KiwiMockAdditions.m in Sources */,
+				AAEA82762E393E10BCBF4F0B /* NSObject+KiwiSpyAdditions.m in Sources */,
+				04C269902AC319929F88F8B9 /* NSObject+KiwiStubAdditions.m in Sources */,
+				B49E13E8C7BEF24B3E45FD87 /* NSObject+KiwiVerifierAdditions.m in Sources */,
+				8E40912B9E1D83649BE9F462 /* NSProxy+KiwiVerifierAdditions.m in Sources */,
+				98D214AC09EFBCBA1C6DA010 /* NSValue+KiwiAdditions.m in Sources */,
+				9DDB3263D49E8BCBE7A554EC /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FB0D2C9B7EFB39A9A747C7CA /* Sources */ = {
+		AF9EE5CEB4FFF1051CB918F6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08F4909C3B5ABB202992A38E /* AFHTTPRequestOperation.m in Sources */,
-				7002EE6A5E5A0B0084633C65 /* AFHTTPRequestOperationManager.m in Sources */,
-				6D402B2C829925A1053BC45B /* AFHTTPSessionManager.m in Sources */,
-				037EC4B0640D2F3CF9878A5B /* AFNetworkActivityIndicatorManager.m in Sources */,
-				94EC37E7EF5F22348681B04C /* AFNetworkReachabilityManager.m in Sources */,
-				3C4A18D0CE951BE3DDCB7D1B /* AFSecurityPolicy.m in Sources */,
-				708E88218563E5C0141957F2 /* AFURLConnectionOperation.m in Sources */,
-				04494C024B29D22E27759FB3 /* AFURLRequestSerialization.m in Sources */,
-				4E0CD178779AFACD0168B4E4 /* AFURLResponseSerialization.m in Sources */,
-				88E59013EFEBFFFF6E649E02 /* AFURLSessionManager.m in Sources */,
-				1771DFCCF5C5ED5F9CBF2EEB /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-dummy.m in Sources */,
-				C0B4BC29BDF4B43307287504 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
-				5A663077CE5A2E7591D271D7 /* UIAlertView+AFNetworking.m in Sources */,
-				3033E648EE00A98FFE87F5FE /* UIButton+AFNetworking.m in Sources */,
-				CA4643FD48DB4CCEB7F2FEAF /* UIImageView+AFNetworking.m in Sources */,
-				5DA2C86EFF9B7D0D993533D6 /* UIProgressView+AFNetworking.m in Sources */,
-				57A56A3A4F83E353A0B2EE36 /* UIRefreshControl+AFNetworking.m in Sources */,
-				C414D1F91558CDA25BD75C46 /* UIWebView+AFNetworking.m in Sources */,
+				F125F0CDCBBA30193AFC6D39 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		59DB4995D79E0F56C8ED3072 /* PBXTargetDependency */ = {
+		0C847BDC8F9B904952312A12 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
-			target = 5D03E40D2B206B4F0239D0B3 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */;
-			targetProxy = 0C2B8A7662FAB771D3A31CD5 /* PBXContainerItemProxy */;
+			target = 6498242C45A38780A3C09F81 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */;
+			targetProxy = E23DA2EBBB1DC9D5F6F2FBBE /* PBXContainerItemProxy */;
 		};
-		6B207F7D0671E437313C6E6E /* PBXTargetDependency */ = {
+		42DDD3B5435495C0244A125C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
-			target = C0B3D285938CDBD7C09C3320 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */;
-			targetProxy = A71FF503C0D29110C2FAFD6A /* PBXContainerItemProxy */;
+			target = 3980640E62AEEFF342677376 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */;
+			targetProxy = F51A5CD6C5BA57FDA8E63E88 /* PBXContainerItemProxy */;
 		};
-		717F8E1F0BFA920A724EA5A3 /* PBXTargetDependency */ = {
+		474DD8599E3700A09021FCA0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking";
-			target = C0B3D285938CDBD7C09C3320 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */;
-			targetProxy = 6E13547794EADD2A6DC4E511 /* PBXContainerItemProxy */;
+			target = 3980640E62AEEFF342677376 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking */;
+			targetProxy = D3FC0999F17A175F3B09D954 /* PBXContainerItemProxy */;
 		};
-		71C22B1275023C799455A3EF /* PBXTargetDependency */ = {
+		645200F97D04D042D829DD9E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi";
-			target = 542726CE34D02AF7E45A9996 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */;
-			targetProxy = 450D4A79C2E8051B5A3FE3AB /* PBXContainerItemProxy */;
+			target = CF63059F21D3520300C09AD3 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi */;
+			targetProxy = 5BEC5D19BADF1BD2841AE887 /* PBXContainerItemProxy */;
 		};
-		7FC4DAE18AD8444B547D769B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
-			target = 220B5C0ED3A2349694FDC974 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */;
-			targetProxy = FC927634987E7FA1B8AAA422 /* PBXContainerItemProxy */;
-		};
-		EF2316B1C841821055110353 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
-			target = 220B5C0ED3A2349694FDC974 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */;
-			targetProxy = 9C1D124292920D8FA8ACB0CB /* PBXContainerItemProxy */;
-		};
-		F35563B56330BAC64A83A2C4 /* PBXTargetDependency */ = {
+		7047DF5936ED84A17B31EA68 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-Mantle";
-			target = 5D03E40D2B206B4F0239D0B3 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */;
-			targetProxy = 6D5D2A7904667C53ED4F70E3 /* PBXContainerItemProxy */;
+			target = 6498242C45A38780A3C09F81 /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle */;
+			targetProxy = 4EF97B0E8573C8CE373E1E80 /* PBXContainerItemProxy */;
 		};
-		FC2B115A7D0A1CAC86F1F489 /* PBXTargetDependency */ = {
+		851A1DB96791849E8F04400C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
+			target = C000419035B9E6734FF11DAF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */;
+			targetProxy = E51C19C0ACCCA64C2B452CB0 /* PBXContainerItemProxy */;
+		};
+		C3FE29B8ABA8D0FCF370CCD0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete";
-			target = 8AB39843A51D427DA606B574 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */;
-			targetProxy = 4440FA45F903C56AE32EA26F /* PBXContainerItemProxy */;
+			target = 5F8653000638B4C4125103D7 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete */;
+			targetProxy = 028C44442DF5F6FB721AD81D /* PBXContainerItemProxy */;
+		};
+		ED1F3D777C672C2A9EA92141 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade";
+			target = C000419035B9E6734FF11DAF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade */;
+			targetProxy = 53ACEA9AC7FBBCB5539B2F5C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		16C0C6A521A33E00C9C18398 /* Debug */ = {
+		031BB704F845EB95A5F9C85D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8B57D6EA1B7AAD8217DF422C /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */;
+			baseConfigurationReference = 2DEF0B9E43511051CFDA9351 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
+			name = Release;
+		};
+		2C838C21FF8D8C3B16F1551B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 70ED2D2CEDEA4D16924EA6BB /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
 			name = Debug;
 		};
-		2FE026BB1A1B85531EECFA7F /* Debug */ = {
+		33EED36E791C1820F3252291 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1903,7 +1919,7 @@
 			};
 			name = Debug;
 		};
-		3E7BCA8203C529679764D650 /* Release */ = {
+		3630648607F5D237BC2E29CE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1937,73 +1953,9 @@
 			};
 			name = Release;
 		};
-		49B8E70BF2022FFD1DFBC03E /* Release */ = {
+		3FCB7CE05FF0662867606959 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AF2BF1DE1D58442CD08EC0C0 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		63C2DF57C8C46EBECE72FB1C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E9DFA3A7B2F0FB5152135BBB /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-Mantle/Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		682A714225EB2C0710572DCB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E55B402FF75765CBC664F624 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		A8E9961CE3279C8B4A2637FA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1BE89C7599E344BA6D699F26 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		AB78DBA4532A4211709A333F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E7AACA8EF1FADE1E604140BF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */;
+			baseConfigurationReference = 62C2A88DAADE5C3334920C2A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch";
@@ -2017,28 +1969,12 @@
 			};
 			name = Debug;
 		};
-		B147816B7386FB5AA1BFF697 /* Debug */ = {
+		3FF6E3B3E201F7633F989B82 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E55B402FF75765CBC664F624 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */;
+			baseConfigurationReference = 35ECB7026521B5F706F02C8F /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		B548A753756DF98A8A9F0323 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 865802332036A75DEEED05AD /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-Mantle/Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -2049,9 +1985,57 @@
 			};
 			name = Release;
 		};
-		CBC3D633EF0107D72DC53DB6 /* Debug */ = {
+		45155A14EA6169FAB1D3C1A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E9DFA3A7B2F0FB5152135BBB /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */;
+			baseConfigurationReference = 2DEF0B9E43511051CFDA9351 /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4F5B2A10984821A601C9569A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EEEEAE22321993C912C05D85 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		85130318AB3BAC91FA80B03A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A682B6D0E7FA9F7271385591 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		B04D97DAAD9029E00100185E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 35ECB7026521B5F706F02C8F /* Pods-HNKGooglePlacesAutocomplete-Example-Mantle-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-Mantle/Pods-HNKGooglePlacesAutocomplete-Example-Mantle-prefix.pch";
@@ -2065,73 +2049,9 @@
 			};
 			name = Debug;
 		};
-		CEBC0F734D0E1D7C2B69928D /* Debug */ = {
+		B422BF94AFE8603B08A6C64B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 865802332036A75DEEED05AD /* Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete/Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		E27F48DEDE555B3AED9249C8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E7AACA8EF1FADE1E604140BF /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		EE60AE4FD0E687E585585235 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D75B074A690D1E34D1DD609E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		FBF143E4BDCC5A1EA1FC8739 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7236E956CC48818885C33A91 /* Pods-HNKGooglePlacesAutocomplete-Example.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		FCF40CF90F8FD4388E55E4A4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8B57D6EA1B7AAD8217DF422C /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */;
+			baseConfigurationReference = A682B6D0E7FA9F7271385591 /* Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking/Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking-prefix.pch";
@@ -2145,82 +2065,162 @@
 			};
 			name = Release;
 		};
+		C753FE6FDD16A2013A54C78E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45CF2C549C5C7D4EA674CC93 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D2212B96536DC54147CE8B95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7DD1C8E0A676D4A26022970E /* Pods-HNKGooglePlacesAutocomplete-Example.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		D5E7DFBC698CE56B403FFAA4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45CF2C549C5C7D4EA674CC93 /* Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi/Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		F35C441BF3890D490B5FEA90 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1EB0717FF7CCD9B875B271BC /* Pods-HNKGooglePlacesAutocomplete-ExampleTests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FF50EFCFF5837C3C28D9D181 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62C2A88DAADE5C3334920C2A /* Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade/Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		015C0FE4024D6EFFA3F27175 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade" */ = {
+		0DB501EDC622F578DC6422CE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKServerFacade" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AB78DBA4532A4211709A333F /* Debug */,
-				E27F48DEDE555B3AED9249C8 /* Release */,
+				3FCB7CE05FF0662867606959 /* Debug */,
+				FF50EFCFF5837C3C28D9D181 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0F49CA2569DCB677EF743D46 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-Mantle" */ = {
+		2475243F5275DE1D3CD7F6FE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CBC3D633EF0107D72DC53DB6 /* Debug */,
-				63C2DF57C8C46EBECE72FB1C /* Release */,
+				F35C441BF3890D490B5FEA90 /* Debug */,
+				4F5B2A10984821A601C9569A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		64B7DF62CDC7AC61B77C99AC /* Build configuration list for PBXProject "Pods" */ = {
+		3FF9FC2E12DDFC406B213603 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FE026BB1A1B85531EECFA7F /* Debug */,
-				3E7BCA8203C529679764D650 /* Release */,
+				85130318AB3BAC91FA80B03A /* Debug */,
+				B422BF94AFE8603B08A6C64B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		665E7E6C33A1ABDA2AFDCE06 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example" */ = {
+		72743F44B855A7D6C858489C /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FBF143E4BDCC5A1EA1FC8739 /* Debug */,
-				EE60AE4FD0E687E585585235 /* Release */,
+				C753FE6FDD16A2013A54C78E /* Debug */,
+				D5E7DFBC698CE56B403FFAA4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8153EBC87F022E18B83D7BD6 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-AFNetworking" */ = {
+		72BB5D234952E4E950F963E9 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				16C0C6A521A33E00C9C18398 /* Debug */,
-				FCF40CF90F8FD4388E55E4A4 /* Release */,
+				45155A14EA6169FAB1D3C1A3 /* Debug */,
+				031BB704F845EB95A5F9C85D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		86BE350412EB1C792121891B /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests-Kiwi" */ = {
+		8411F9522690FB5E731FFCA8 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B147816B7386FB5AA1BFF697 /* Debug */,
-				682A714225EB2C0710572DCB /* Release */,
+				33EED36E791C1820F3252291 /* Debug */,
+				3630648607F5D237BC2E29CE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B01AED520791D19D1422B068 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-ExampleTests" */ = {
+		AD39456912062B7724FC995B /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A8E9961CE3279C8B4A2637FA /* Debug */,
-				49B8E70BF2022FFD1DFBC03E /* Release */,
+				2C838C21FF8D8C3B16F1551B /* Debug */,
+				D2212B96536DC54147CE8B95 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B1CB54063CFC4271E434C074 /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-HNKGooglePlacesAutocomplete" */ = {
+		C4773A57D8C41545F7EC34BE /* Build configuration list for PBXNativeTarget "Pods-HNKGooglePlacesAutocomplete-Example-Mantle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CEBC0F734D0E1D7C2B69928D /* Debug */,
-				B548A753756DF98A8A9F0323 /* Release */,
+				B04D97DAAD9029E00100185E /* Debug */,
+				3FF6E3B3E201F7633F989B82 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 6693617DAA1242D75F0C3B4F /* Project object */;
+	rootObject = 15402930F01A4867F7C30448 /* Project object */;
 }

--- a/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
+++ b/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
@@ -169,21 +169,36 @@ static HNKGooglePlacesAutocompleteQuery *sharedQuery = nil;
         configBlock(configForRequest);
     }
 
-    if ([self isValidSearchQuery:searchQuery]) {
+    BOOL isInvalidSearchQuery = [self isInvalidSearchQuery:searchQuery];
+
+    if ([self shouldMakeServerRequestForSearchQuery:searchQuery] && !isInvalidSearchQuery) {
 
         [self serverRequestWithSearchQuery:searchQuery configuration:configForRequest completion:completion];
 
     } else {
 
-        [self completeWithErrorForInvalidSearchQuery:searchQuery completion:completion];
+        if (isInvalidSearchQuery) {
+
+            [self completeWithErrorForInvalidSearchQuery:searchQuery completion:completion];
+        }
     }
 }
 
 #pragma mark - Helpers
 
-- (BOOL)isValidSearchQuery:(NSString *)searchQuery
+- (BOOL)shouldMakeServerRequestForSearchQuery:(NSString *)searchQuery
 {
-    return ((searchQuery != nil) && ![searchQuery isEqualToString:@""]);
+    BOOL doesMeetOffset = (searchQuery.length >= self.configuration.offset);
+
+    return doesMeetOffset;
+}
+
+- (BOOL)isInvalidSearchQuery:(NSString *)searchQuery
+{
+    BOOL isNil = searchQuery == nil;
+    BOOL isEmpty = [searchQuery isEqualToString:@""];
+
+    return (isNil || isEmpty);
 }
 
 - (void)serverRequestWithSearchQuery:(NSString *)searchQuery

--- a/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
+++ b/Pod/Classes/HNKGooglePlacesAutocompleteQuery.m
@@ -188,9 +188,10 @@ static HNKGooglePlacesAutocompleteQuery *sharedQuery = nil;
 
 - (BOOL)shouldMakeServerRequestForSearchQuery:(NSString *)searchQuery
 {
+    BOOL hasNoOffset = (self.configuration.offset == NSNotFound);
     BOOL doesMeetOffset = (searchQuery.length >= self.configuration.offset);
 
-    return doesMeetOffset;
+    return hasNoOffset || doesMeetOffset;
 }
 
 - (BOOL)isInvalidSearchQuery:(NSString *)searchQuery


### PR DESCRIPTION
i.e. if `offset` was `3`, server was still being hit for search queries of length `1` and `2` and returning an error 
